### PR TITLE
fix axe and sword options for Bretonnians

### DIFF
--- a/Bretonnian Knights.cat
+++ b/Bretonnian Knights.cat
@@ -41,11 +41,8 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="5def-eac6-eeda-7cc7" targetId="34fd-d6a3-50ee-ee06">
-              <modifiers>
-                <modifier type="set" value="5" field="points"/>
-              </modifiers>
-            </entryLink>
+            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="5def-eac6-eeda-7cc7" targetId="34fd-d6a3-50ee-ee06" />
+            <entryLink import="true" name="Axe" hidden="false" type="selectionEntry" id="b0ba-11ef-808e-3250" targetId="5d01-06b9-3a86-73c9"/>
             <entryLink import="true" name="Double Handed Weapon" hidden="false" type="selectionEntry" id="c9ae-26b4-b2cd-bf00" targetId="a0a1-b311-e3aa-6c3b"/>
             <entryLink import="true" name="Morning Star" hidden="false" type="selectionEntry" id="d1e4-34bc-5ff7-a80a" targetId="d5f3-1906-da91-4e8f"/>
             <entryLink import="true" name="Lance" hidden="false" type="selectionEntry" id="5301-d3c5-93d5-4c8c" targetId="5223-13a6-14ec-f372">
@@ -88,11 +85,7 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="b24a-f142-629b-db98" targetId="34fd-d6a3-50ee-ee06">
-              <modifiers>
-                <modifier type="set" value="5" field="points"/>
-              </modifiers>
-            </entryLink>
+            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="b24a-f142-629b-db98" targetId="34fd-d6a3-50ee-ee06"/>
             <entryLink import="true" name="Axe" hidden="false" type="selectionEntry" id="ab17-453d-455-3c17" targetId="5d01-06b9-3a86-73c9"/>
             <entryLink import="true" name="Spear" hidden="false" type="selectionEntry" id="3636-12a9-e714-85e8" targetId="005e-e397-8108-f198"/>
           </entryLinks>
@@ -131,11 +124,7 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="ea88-dc7-9478-5be8" targetId="34fd-d6a3-50ee-ee06">
-              <modifiers>
-                <modifier type="set" value="5" field="points"/>
-              </modifiers>
-            </entryLink>
+            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="ea88-dc7-9478-5be8" targetId="34fd-d6a3-50ee-ee06" />
             <entryLink import="true" name="Double Handed Weapon" hidden="false" type="selectionEntry" id="90d-3b9b-5a85-a002" targetId="a0a1-b311-e3aa-6c3b"/>
             <entryLink import="true" name="Spear" hidden="false" type="selectionEntry" id="3983-6285-45af-d2ea" targetId="005e-e397-8108-f198"/>
             <entryLink import="true" name="Axe" hidden="false" type="selectionEntry" id="dc03-90a8-d175-a98e" targetId="5d01-06b9-3a86-73c9"/>


### PR DESCRIPTION
On the Bretonnian list, Swords were miss priced at 5gc and axes were not allowed for knights.  Going off [this doc](https://broheim.net/downloads/warbands/unofficial/Bretonnian%20Knights.pdf) for prices and options.