### PR TITLE
Fixing Cult of the Possessed mutation cost issue

### DIFF
--- a/Possessed.cat
+++ b/Possessed.cat
@@ -2702,7 +2702,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="20"/>
+            <cost name="pts" typeId="points" value="40"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2728,7 +2728,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="50"/>
+            <cost name="pts" typeId="points" value="100"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2754,7 +2754,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="35"/>
+            <cost name="pts" typeId="points" value="70"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2783,7 +2783,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             <entryLink id="6297d54b-6834-0b76-33ef-e8a1e34c9505" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="40"/>
+            <cost name="pts" typeId="points" value="80"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2809,7 +2809,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="30"/>
+            <cost name="pts" typeId="points" value="60"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2835,7 +2835,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="35"/>
+            <cost name="pts" typeId="points" value="70"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2861,7 +2861,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="40"/>
+            <cost name="pts" typeId="points" value="80"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2887,7 +2887,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="40"/>
+            <cost name="pts" typeId="points" value="80"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
@@ -2917,7 +2917,7 @@ for details.</description>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="40"/>
+            <cost name="pts" typeId="points" value="80"/>
             <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>


### PR DESCRIPTION
The implementation of the mutation costings was wrong (first one costs 0, extras cost x.). The correct rule is first one costs x, extras cost 2x - no freebies.
 
I've set the prices to 2x by default so that the "first mutation discount" brings the price down to half that, i.e. the undoubled cost (x).