### PR TITLE
Update for 1a warbands and add 1a Miscellaneous  items

### DIFF
--- a/Dwarven_Tresure_Hunters.cat
+++ b/Dwarven_Tresure_Hunters.cat
@@ -172,7 +172,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d0e92522-22ae-9428-38f8-cf4e8df9ea6e" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="d0e92522-22ae-9428-38f8-cf4e8df9ea6e" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -360,7 +360,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="96307387-d448-cbca-a957-3e7c866e02fb" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="96307387-d448-cbca-a957-3e7c866e02fb" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -543,8 +543,8 @@
           </constraints>
           <entryLinks>
             <entryLink id="5b0f29e6-712f-4378-a8b5-0b4fa16d01aa" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Dwarven)"/>
-            <entryLink id="784ca960-9523-8edf-ab73-c01a391b3db0" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="411a9fc8-a580-e87e-97b6-0ebd6d6a4f25" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="784ca960-9523-8edf-ab73-c01a391b3db0" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="411a9fc8-a580-e87e-97b6-0ebd6d6a4f25" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -728,9 +728,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
             <entryLink id="c211a314-0f43-9582-e03a-7bc39bbb72d1" name="Special Skils (Dwarven)" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
@@ -949,7 +949,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" name="Skills" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" name="Skills" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1132,8 +1132,8 @@
           </constraints>
           <entryLinks>
             <entryLink id="fc289191-eea6-1182-812e-1b3d594bf78e" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Dwarven)"/>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
             <entryLink id="6f7dc65c-cbc9-9058-2d23-8e3bb45b1b57" hidden="false" collective="false" import="true" targetId="faa680e5-6367-a85f-790f-7a9369481ec5" type="selectionEntryGroup" name="Troll Slayer Skills"/>
           </entryLinks>
           <costs>

--- a/Dwarven_Tresure_Hunters.cat
+++ b/Dwarven_Tresure_Hunters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8315579e-b80d-5ed1-7a51-d85cdf59c06b" name="Dwarf Treasure Hunters (1a)" revision="21" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="8315579e-b80d-5ed1-7a51-d85cdf59c06b" name="Dwarf Treasure Hunters (1a)" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="2d1dabde-1182-a9db-6186-35bff94b4a69" name="Beardlings" page="0" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -110,7 +110,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="2d1dabde-1182-a9db-6186-35bff94b4a69-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="2d1dabde-1182-a9db-6186-35bff94b4a69-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="20336714-186a-3b26-ac83-5dce01a31d18" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -119,7 +119,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="261c7c67-8cbc-b4a3-2a66-4b0ce82fe894" name="Equipment" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="261c7c67-8cbc-b4a3-2a66-4b0ce82fe894" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -132,7 +132,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="e64c18fe-1481-78b0-2e77-85cd8aeac807" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="e64c18fe-1481-78b0-2e77-85cd8aeac807" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -152,7 +152,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c4447f30-84d5-6f6f-4a77-68133ac35e64" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="c4447f30-84d5-6f6f-4a77-68133ac35e64" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -172,7 +172,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d0e92522-22ae-9428-38f8-cf4e8df9ea6e" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="d0e92522-22ae-9428-38f8-cf4e8df9ea6e" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -181,8 +181,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="26ace36d-ae02-c7c3-f578-c9fbe297ab22" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="a6bd09d9-52ab-29a2-eb9f-6a61061deb6e" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="26ace36d-ae02-c7c3-f578-c9fbe297ab22" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
+        <entryLink id="a6bd09d9-52ab-29a2-eb9f-6a61061deb6e" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25"/>
@@ -298,7 +298,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="6499c7ac-217f-8b53-fb9b-6488c5e306aa-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="6499c7ac-217f-8b53-fb9b-6488c5e306aa-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b32c1092-1932-1447-3ba3-c883f1936575" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -307,7 +307,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a796128c-418c-3557-e2f1-a2066b5f34be" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="a796128c-418c-3557-e2f1-a2066b5f34be" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -320,7 +320,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5661dcaf-fc8a-caaa-95d8-82d14e1c7974" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="5661dcaf-fc8a-caaa-95d8-82d14e1c7974" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -340,7 +340,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9c938c59-3e70-ceb1-b912-c654769a4f48" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="9c938c59-3e70-ceb1-b912-c654769a4f48" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -360,7 +360,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="96307387-d448-cbca-a957-3e7c866e02fb" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="96307387-d448-cbca-a957-3e7c866e02fb" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -369,8 +369,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="a9d2c40a-ccdb-3d29-aebe-4e3b34c8e16b" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="004156cb-821f-cf6b-7434-9a459a6c9dff" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="a9d2c40a-ccdb-3d29-aebe-4e3b34c8e16b" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
+        <entryLink id="004156cb-821f-cf6b-7434-9a459a6c9dff" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40"/>
@@ -494,7 +494,7 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7daa68c-56da-e5c0-ff61-454d0e70fc3a" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -503,7 +503,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -516,7 +516,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -529,7 +529,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -542,9 +542,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5b0f29e6-712f-4378-a8b5-0b4fa16d01aa" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
-            <entryLink id="784ca960-9523-8edf-ab73-c01a391b3db0" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="411a9fc8-a580-e87e-97b6-0ebd6d6a4f25" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
+            <entryLink id="5b0f29e6-712f-4378-a8b5-0b4fa16d01aa" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Dwarven)"/>
+            <entryLink id="784ca960-9523-8edf-ab73-c01a391b3db0" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="411a9fc8-a580-e87e-97b6-0ebd6d6a4f25" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -677,10 +677,10 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="4d92a047-89ba-4de5-cc7e-17b47e04553d" hidden="false" targetId="9ad0512c-c5d0-ff51-ea39-68175a042370" type="rule"/>
+        <infoLink id="4d92a047-89ba-4de5-cc7e-17b47e04553d" hidden="false" targetId="9ad0512c-c5d0-ff51-ea39-68175a042370" type="rule" name="Leader"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b463eea6-c00c-2a2e-4538-087cf51cf5ae-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="b463eea6-c00c-2a2e-4538-087cf51cf5ae-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a359fe11-ad97-3216-79e2-42fa0fcef557" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -689,7 +689,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -702,7 +702,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -715,7 +715,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -728,9 +728,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
             <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
             <entryLink id="c211a314-0f43-9582-e03a-7bc39bbb72d1" name="Special Skils (Dwarven)" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
@@ -756,7 +756,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true" name="Stash"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5f07-20e8-34d1-e340" name="Wyrdstone" hidden="false" collective="false" import="true" type="upgrade">
@@ -768,7 +768,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -887,7 +887,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="579963c2-b42f-2254-f6e0-c4746cd13fc4" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -896,7 +896,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -909,7 +909,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -929,7 +929,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -958,8 +958,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="ead51f82-ca51-5519-9a8a-b462449cf11d" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="3ace7cec-b98a-8120-c6ce-caf458afb673" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="ead51f82-ca51-5519-9a8a-b462449cf11d" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
+        <entryLink id="3ace7cec-b98a-8120-c6ce-caf458afb673" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40"/>
@@ -1083,7 +1083,7 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4c359fa9-8570-3c9d-56b9-c03be92aa0f6" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1092,7 +1092,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1105,7 +1105,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1118,7 +1118,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1131,10 +1131,10 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fc289191-eea6-1182-812e-1b3d594bf78e" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="6f7dc65c-cbc9-9058-2d23-8e3bb45b1b57" hidden="false" collective="false" import="true" targetId="faa680e5-6367-a85f-790f-7a9369481ec5" type="selectionEntryGroup"/>
+            <entryLink id="fc289191-eea6-1182-812e-1b3d594bf78e" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Dwarven)"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="6f7dc65c-cbc9-9058-2d23-8e3bb45b1b57" hidden="false" collective="false" import="true" targetId="faa680e5-6367-a85f-790f-7a9369481ec5" type="selectionEntryGroup" name="Troll Slayer Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1176,8 +1176,8 @@
     </rule>
   </rules>
   <infoLinks>
-    <infoLink id="f98676e7-07fd-7cea-03c3-483ac99b0435" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule"/>
-    <infoLink id="21dc314b-01d7-9a0e-3606-fc4b640d9271" hidden="false" targetId="dc466bee-0dd9-eaa2-db68-d16f58af2521" type="rule"/>
+    <infoLink id="f98676e7-07fd-7cea-03c3-483ac99b0435" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule" name="Hatred"/>
+    <infoLink id="21dc314b-01d7-9a0e-3606-fc4b640d9271" hidden="false" targetId="dc466bee-0dd9-eaa2-db68-d16f58af2521" type="rule" name="EXP Advancement"/>
   </infoLinks>
   <sharedSelectionEntries>
     <selectionEntry id="8acf5ee1-3430-be22-ec94-15b12e15e497" name="+1 A" page="0" hidden="false" collective="true" import="true" type="upgrade">
@@ -1506,7 +1506,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule"/>
+            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule" name="Avoid stun"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="10"/>
@@ -1537,7 +1537,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="5"/>
@@ -1554,7 +1554,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
+            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="80"/>
@@ -1608,15 +1608,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry"/>
-        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry"/>
-        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry"/>
-        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry"/>
-        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry"/>
-        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry"/>
-        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
-        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry"/>
-        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry"/>
+        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I"/>
+        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry" name="-1 S"/>
+        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS"/>
+        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS"/>
+        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T"/>
+        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry" name="-1 A"/>
+        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
+        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry" name="-1 LD"/>
+        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry" name="-1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="36e117d8-419f-59b9-e337-512db3c6c990" name="Characteristic Increases" hidden="false" collective="false" import="true">
@@ -1631,15 +1631,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry"/>
-        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry"/>
-        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry"/>
-        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry"/>
-        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry"/>
-        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry"/>
-        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
-        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry"/>
-        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry"/>
+        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry" name="+1 I"/>
+        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry" name="+1 S"/>
+        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry" name="+1 WS"/>
+        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry" name="+1 BS"/>
+        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry" name="+1 T"/>
+        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry" name="+1 A"/>
+        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry" name="+1 M"/>
+        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry" name="+1 LD"/>
+        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry" name="+1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bd8689c9-bc5c-df7b-87b9-aad34e27a295" name="Combat Skills" hidden="false" collective="false" import="true">
@@ -1753,10 +1753,10 @@ only applies when they are armed with normal swords or weeping blades, and not w
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
-        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
-        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
+        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
+        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup" name="Missile Weapons"/>
+        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup" name="War Gear"/>
+        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
@@ -1775,7 +1775,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="a022bf96-d456-1fd8-41e6-fd0882f5ed93" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1786,7 +1786,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="147a2e0f-6184-1325-8035-d2927d51d84b" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1815,7 +1815,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1846,7 +1846,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="c0d64e18-0c72-24b7-637e-dc81b4d3a96c" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1875,7 +1875,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1898,8 +1898,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule"/>
+            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule" name="Difficult To Use"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="37972d57-6f98-64fc-0e7c-cc3c30174a11" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1910,7 +1910,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="8e88bb3e-d082-b48e-93b6-dab2f623c044" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1939,7 +1939,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1962,7 +1962,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="fcc1d76e-a482-00a0-03fb-fecd9deb538e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1973,7 +1973,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="36d824d0-dd74-91d1-37e5-e282b64fe00d" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2002,7 +2002,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2025,8 +2025,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule"/>
-            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule" name="Strike Last"/>
+            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="eafc9bba-c5a2-09d3-627c-c5c102a70528" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2037,7 +2037,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="17f34d68-ed7e-7fd7-00c3-b30f2fba9f5b" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2066,7 +2066,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2089,9 +2089,9 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule"/>
-            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule"/>
-            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule" name="Strike First"/>
+            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule" name="Unwieldy"/>
+            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="3ef9bbbf-a875-133e-a275-fb47750ca7d8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2102,7 +2102,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="041275cb-57dc-07be-a66f-eca71d672654" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2131,7 +2131,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2154,7 +2154,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="e1ae1bcf-84ef-dd9f-ae28-ed867c321df4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2165,7 +2165,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="45578796-d11f-685a-9af8-8f6414cfd8c2" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2194,7 +2194,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2220,7 +2220,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2237,7 +2237,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule"/>
+            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule" name="ConCussion"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="0608e581-cb18-48b9-ab15-a1c7143f9203" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2262,7 +2262,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2277,7 +2277,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2300,7 +2300,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2317,8 +2317,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="aaef08ab-959e-c1cb-cce3-c9409cfc73c2" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2329,7 +2329,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="0475f49e-861d-ce19-cc21-039711d0f9b3" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2358,7 +2358,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2381,8 +2381,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule"/>
-            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule" name="Cavalry Weapon"/>
+            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="50469495-65e4-8313-fb4a-b47e3f3d4e5d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2393,7 +2393,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="2455bb21-4bd8-2e1b-7fc8-ca87f7382418" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2422,7 +2422,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2486,8 +2486,8 @@ ignores the special rules for Animosity.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="f73a092c-8b45-e4ce-68a1-5749bb1c8a66" hidden="false" targetId="6118263e-03c4-68f7-694d-6ceebac4e80b" type="rule"/>
-            <infoLink id="5cfa07be-11c4-a683-aff5-7c41299022a9" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="f73a092c-8b45-e4ce-68a1-5749bb1c8a66" hidden="false" targetId="6118263e-03c4-68f7-694d-6ceebac4e80b" type="rule" name="Cutting edge"/>
+            <infoLink id="5cfa07be-11c4-a683-aff5-7c41299022a9" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="35fe4f59-9c18-3df3-6bc7-de497e7b989d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2498,7 +2498,7 @@ ignores the special rules for Animosity.</description>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="7212451c-a885-f467-fa99-9bb211879f22" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="7212451c-a885-f467-fa99-9bb211879f22" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="916867c0-9f8d-c937-5614-378e26c2b372" name="Dwarven Starting" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2527,7 +2527,7 @@ ignores the special rules for Animosity.</description>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="07b3cde8-2fd5-2725-80f2-7458c2d711b1" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="07b3cde8-2fd5-2725-80f2-7458c2d711b1" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2663,8 +2663,8 @@ a duelling pistol have a +1 bonus to hit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
-            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
+            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
+            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -2682,7 +2682,7 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2700,9 +2700,9 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
-            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule"/>
-            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
+            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
+            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule" name="Move Of Fire"/>
+            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2817,7 +2817,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2841,7 +2841,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         </selectionEntry>
         <selectionEntry id="d7277e6e-49d8-50cb-988c-84bb7240da31" name="Maddness: Stupidity" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
+            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2850,7 +2850,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         </selectionEntry>
         <selectionEntry id="abc70d10-8ad7-23a1-6eb0-e05474350e3f" name="Madness: Frenzy" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule"/>
+            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule" name="Frenzy"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2864,7 +2864,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2883,7 +2883,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry">
+            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2912,7 +2912,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2930,7 +2930,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2970,7 +2970,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3562,7 +3562,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3576,7 +3576,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3590,7 +3590,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3604,7 +3604,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3621,7 +3621,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3635,7 +3635,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3649,7 +3649,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="100"/>
@@ -3674,7 +3674,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3688,7 +3688,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="20"/>
@@ -3702,7 +3702,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3716,7 +3716,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3757,7 +3757,7 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3809,7 +3809,7 @@ Side effects: Mandrake Root is highly poisonous. At the end of the battle, roll 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="25"/>
@@ -3837,7 +3837,7 @@ on the Exploration chart as long as the Hero who possesses this map was not take
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3885,7 +3885,7 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3942,7 +3942,7 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3970,7 +3970,7 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3984,7 +3984,7 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3992,6 +3992,11 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
           </costs>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Test import" id="6a07-b97c-9873-8a16" hidden="false" import="true" flatten="false" collapsible="false" collective="false">
+      <entryLinks>
+        <entryLink import="true" name="Equipment" hidden="false" id="e3f7-0668-ec64-5517" type="selectionEntryGroup" targetId="2247-1f56-bc59-0ead"/>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
@@ -4084,4 +4089,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="85d6-13e6-1e48-8d4a" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Marienburg_Mercinaries.cat
+++ b/Marienburg_Mercinaries.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d7899d8b-a172-7e27-aec7-b9c51cb475c1" name="Marienburgers (1a)" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="d7899d8b-a172-7e27-aec7-b9c51cb475c1" name="Marienburgers (1a)" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Champion" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -122,7 +122,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -311,7 +311,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -523,7 +523,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -604,7 +604,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -732,7 +732,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -950,7 +950,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1145,7 +1145,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3856,4 +3856,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="afea-7d77-4f80-8a27" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Middenheim_Mercinaries.cat
+++ b/Middenheim_Mercinaries.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="51919a76-f868-1581-224f-24394fbb0d64" name="Middenheimers (1a)" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="51919a76-f868-1581-224f-24394fbb0d64" name="Middenheimers (1a)" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Champion" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -122,7 +122,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -308,7 +308,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -503,7 +503,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -584,7 +584,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -712,7 +712,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -913,7 +913,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1091,7 +1091,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3822,4 +3822,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="3bba-ce00-caac-f9ea" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Ork_Mob.cat
+++ b/Ork_Mob.cat
@@ -169,9 +169,9 @@
           </constraints>
           <entryLinks>
             <entryLink id="fc289191-eea6-1182-812e-1b3d594bf78e" name="Special Skils (Ork Mob)" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="67b818c7-d67c-76c1-3c50-aaf2384cb102" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="67b818c7-d67c-76c1-3c50-aaf2384cb102" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -680,11 +680,11 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
             <entryLink id="afdca5cf-1fd7-4c9b-b972-4aa05ab143be" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -878,7 +878,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
             <entryLink id="9429a81e-e533-f91f-17e1-2c05cf86b9b8" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
           </entryLinks>
           <costs>
@@ -1057,7 +1057,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
           </constraints>
           <entryLinks>
             <entryLink id="5b0f29e6-712f-4378-a8b5-0b4fa16d01aa" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
-            <entryLink id="37d25143-ee22-bddd-39e0-f0a47301f611" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="37d25143-ee22-bddd-39e0-f0a47301f611" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>

--- a/Ork_Mob.cat
+++ b/Ork_Mob.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8b66f7c3-fdd7-fcea-eb91-086959d72140" name="Ork Mob (1a)" revision="18" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="8b66f7c3-fdd7-fcea-eb91-086959d72140" name="Ork Mob (1a)" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="0094-a0e7-9fc9-5aa2" name="Ork Mob Rules" shortName="Broheim Rules (1a)" publisher="https://broheim.net/downloads/warbands/official/Orc%20Mob.pdf" publisherUrl="https://broheim.net/downloads/warbands/official/Orc%20Mob.pdf"/>
   </publications>
@@ -116,7 +116,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4c359fa9-8570-3c9d-56b9-c03be92aa0f6" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -125,7 +125,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -138,7 +138,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -151,7 +151,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup">
+            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases">
               <modifiers>
                 <modifier type="increment" field="minSelections" value="0"/>
               </modifiers>
@@ -168,10 +168,10 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fc289191-eea6-1182-812e-1b3d594bf78e" name="Specia Skils(orc)" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="67b818c7-d67c-76c1-3c50-aaf2384cb102" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
+            <entryLink id="fc289191-eea6-1182-812e-1b3d594bf78e" name="Special Skils (Ork Mob)" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="67b818c7-d67c-76c1-3c50-aaf2384cb102" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -334,7 +334,7 @@
         <infoLink id="0c5b6f54-ad66-832d-87ff-3fcfcea170eb" name="Not Orcs" hidden="false" targetId="d01f3b76-116e-6c48-fad5-666190491edb" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15"/>
@@ -476,7 +476,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
         <infoLink id="9ff0f712-acd3-8d2c-bb74-e58014a57168" name="Not Orcs" hidden="false" targetId="d01f3b76-116e-6c48-fad5-666190491edb" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="38f17f5d-5cb6-91b3-1e1a-97d8f3eb211e" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -485,7 +485,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -498,7 +498,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -507,7 +507,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="faa8d372-77d4-33a4-1a08-49fe27633c52" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="faa8d372-77d4-33a4-1a08-49fe27633c52" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15"/>
@@ -632,7 +632,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a359fe11-ad97-3216-79e2-42fa0fcef557" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -641,7 +641,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -654,7 +654,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -667,7 +667,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -680,11 +680,11 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="afdca5cf-1fd7-4c9b-b972-4aa05ab143be" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="afdca5cf-1fd7-4c9b-b972-4aa05ab143be" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -816,7 +816,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
         <infoLink id="407b5241-9c98-2d54-937b-60dfbd5e588f" name="Animosity" hidden="false" targetId="7c09af65-6094-ddb7-b0be-cd7a970dbef0" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="579963c2-b42f-2254-f6e0-c4746cd13fc4" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -825,7 +825,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -838,7 +838,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -858,7 +858,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -878,8 +878,8 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
-            <entryLink id="9429a81e-e533-f91f-17e1-2c05cf86b9b8" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="9429a81e-e533-f91f-17e1-2c05cf86b9b8" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -889,7 +889,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
       </selectionEntries>
       <entryLinks>
         <entryLink id="ead51f82-ca51-5519-9a8a-b462449cf11d" name="Promoted" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="3ace7cec-b98a-8120-c6ce-caf458afb673" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="3ace7cec-b98a-8120-c6ce-caf458afb673" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25"/>
@@ -1008,7 +1008,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7daa68c-56da-e5c0-ff61-454d0e70fc3a" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1017,7 +1017,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1030,7 +1030,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1043,7 +1043,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1056,8 +1056,8 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5b0f29e6-712f-4378-a8b5-0b4fa16d01aa" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
-            <entryLink id="37d25143-ee22-bddd-39e0-f0a47301f611" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
+            <entryLink id="5b0f29e6-712f-4378-a8b5-0b4fa16d01aa" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
+            <entryLink id="37d25143-ee22-bddd-39e0-f0a47301f611" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1096,7 +1096,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f67c-fd08-cd7d-3a48" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true" name="Stash"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4d4f-2d67-018a-fa00" name="Wyrdstone" hidden="false" collective="false" import="true" type="upgrade">
@@ -1108,7 +1108,7 @@ Goblins are far too afraid of Orcs to challenge them individually.</description>
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" name="Equipment" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -1254,7 +1254,7 @@ Trolls do not gain experience.</description>
         <infoLink id="0812a670-2de8-7c31-6e8d-246e7b7f0af7" name="Fear" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c32c3458-18e5-acbf-7d39-245aa6d7689b-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="c32c3458-18e5-acbf-7d39-245aa6d7689b-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="200"/>
@@ -1607,7 +1607,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule"/>
+            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule" name="Avoid stun:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="10"/>
@@ -1638,7 +1638,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="5"/>
@@ -1655,7 +1655,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
+            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="80"/>
@@ -1704,15 +1704,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry"/>
-        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry"/>
-        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry"/>
-        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry"/>
-        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry"/>
-        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry"/>
-        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
-        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry"/>
-        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry"/>
+        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I"/>
+        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry" name="-1 S"/>
+        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS"/>
+        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS"/>
+        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T"/>
+        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry" name="-1 A"/>
+        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
+        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry" name="-1 LD"/>
+        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry" name="-1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="36e117d8-419f-59b9-e337-512db3c6c990" name="Characteristic Increases" hidden="false" collective="false" import="true">
@@ -1727,15 +1727,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry"/>
-        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry"/>
-        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry"/>
-        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry"/>
-        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry"/>
-        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry"/>
-        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
-        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry"/>
-        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry"/>
+        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry" name="+1 I"/>
+        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry" name="+1 S"/>
+        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry" name="+1 WS"/>
+        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry" name="+1 BS"/>
+        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry" name="+1 T"/>
+        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry" name="+1 A"/>
+        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry" name="+1 M"/>
+        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry" name="+1 LD"/>
+        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry" name="+1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bd8689c9-bc5c-df7b-87b9-aad34e27a295" name="Combat Skills" hidden="false" collective="false" import="true">
@@ -1849,10 +1849,10 @@ only applies when they are armed with normal swords or weeping blades, and not w
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
-        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
-        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
+        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
+        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup" name="Missile Weapons"/>
+        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup" name="War Gear"/>
+        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
@@ -1877,7 +1877,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="a022bf96-d456-1fd8-41e6-fd0882f5ed93" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1888,7 +1888,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1903,7 +1903,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1934,7 +1934,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1949,7 +1949,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1972,8 +1972,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule"/>
+            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule" name="Difficult To Use"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="37972d57-6f98-64fc-0e7c-cc3c30174a11" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1984,7 +1984,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1999,7 +1999,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2022,7 +2022,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="fcc1d76e-a482-00a0-03fb-fecd9deb538e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2033,7 +2033,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2048,7 +2048,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2071,8 +2071,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule"/>
-            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule" name="Strike Last"/>
+            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="eafc9bba-c5a2-09d3-627c-c5c102a70528" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2083,7 +2083,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2098,7 +2098,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2121,9 +2121,9 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule"/>
-            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule"/>
-            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule" name="Strike First"/>
+            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule" name="Unwieldy:"/>
+            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="3ef9bbbf-a875-133e-a275-fb47750ca7d8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2134,7 +2134,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2149,7 +2149,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2172,7 +2172,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="e1ae1bcf-84ef-dd9f-ae28-ed867c321df4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2183,7 +2183,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2198,7 +2198,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2224,7 +2224,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2241,7 +2241,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule"/>
+            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule" name="ConCussion"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="0608e581-cb18-48b9-ab15-a1c7143f9203" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2252,7 +2252,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2267,7 +2267,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2290,7 +2290,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2307,8 +2307,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="aaef08ab-959e-c1cb-cce3-c9409cfc73c2" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2319,7 +2319,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2334,7 +2334,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2357,8 +2357,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule"/>
-            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule" name="Cavalry Weapon"/>
+            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="50469495-65e4-8313-fb4a-b47e3f3d4e5d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2369,7 +2369,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2384,7 +2384,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2452,7 +2452,7 @@ ignores the special rules for Animosity.</description>
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="f941a52c-a11a-fef5-dd80-d7a857d3789a" hidden="false" collective="false" import="true" targetId="5cce5525-3057-85be-427a-ceeac0d35c53" type="selectionEntryGroup"/>
+        <entryLink id="f941a52c-a11a-fef5-dd80-d7a857d3789a" hidden="false" collective="false" import="true" targetId="5cce5525-3057-85be-427a-ceeac0d35c53" type="selectionEntryGroup" name="Waaagg magic"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="38175608-757c-9eb5-59a8-2f7b6b1019e2" name="Missile Weapons" hidden="false" collective="false" import="true">
@@ -2563,8 +2563,8 @@ a duelling pistol have a +1 bonus to hit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
-            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
+            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
+            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -2582,7 +2582,7 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2600,9 +2600,9 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
-            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule"/>
-            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
+            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
+            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule" name="Move Of Fire"/>
+            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2717,7 +2717,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2741,7 +2741,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         </selectionEntry>
         <selectionEntry id="d7277e6e-49d8-50cb-988c-84bb7240da31" name="Maddness: Stupidity" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
+            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2750,7 +2750,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         </selectionEntry>
         <selectionEntry id="abc70d10-8ad7-23a1-6eb0-e05474350e3f" name="Madness: Frenzy" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule"/>
+            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule" name="Frenzy"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2764,7 +2764,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2783,7 +2783,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry">
+            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2812,7 +2812,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2830,7 +2830,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2870,7 +2870,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3029,11 +3029,11 @@ with a bow or crossbow (but not a crossbow pistol).</description>
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="e0a34910-f971-a9f6-2735-86e721bb904a" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
-        <entryLink id="fe0f976f-7e51-73d0-e9c4-ddb8c2facad4" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-        <entryLink id="5efa8246-ad2e-146b-67fe-b747a1c0cb22" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-        <entryLink id="41fcb00f-2237-9ca0-5b99-9f34f4e834e6" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-        <entryLink id="cb1b0dc4-3b79-b7d4-84c6-0353e001d60f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
+        <entryLink id="e0a34910-f971-a9f6-2735-86e721bb904a" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+        <entryLink id="fe0f976f-7e51-73d0-e9c4-ddb8c2facad4" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+        <entryLink id="5efa8246-ad2e-146b-67fe-b747a1c0cb22" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+        <entryLink id="41fcb00f-2237-9ca0-5b99-9f34f4e834e6" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+        <entryLink id="cb1b0dc4-3b79-b7d4-84c6-0353e001d60f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="15a59018-e588-319b-6ce2-450c80998e97" name="Special Skils (Ork Mob)" hidden="false" collective="false" import="true">
@@ -3146,7 +3146,7 @@ with a bow or crossbow (but not a crossbow pistol).</description>
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="98db0173-7ac2-701c-0c53-89b88969f607" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup"/>
+        <entryLink id="98db0173-7ac2-701c-0c53-89b88969f607" hidden="false" collective="false" import="true" targetId="15a59018-e588-319b-6ce2-450c80998e97" type="selectionEntryGroup" name="Special Skils (Ork Mob)"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="2a62fe9a-16ae-b087-f5a5-47f19da37c89" name="Speed Skills" hidden="false" collective="false" import="true">
@@ -3487,7 +3487,7 @@ or split between the two closest enemy targets.</characteristic>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3501,7 +3501,7 @@ or split between the two closest enemy targets.</characteristic>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3515,7 +3515,7 @@ or split between the two closest enemy targets.</characteristic>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3529,7 +3529,7 @@ or split between the two closest enemy targets.</characteristic>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3546,7 +3546,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3560,7 +3560,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3574,7 +3574,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="100"/>
@@ -3599,7 +3599,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3613,7 +3613,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="20"/>
@@ -3627,7 +3627,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3641,7 +3641,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3682,7 +3682,7 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3734,7 +3734,7 @@ Side effects: Mandrake Root is highly poisonous. At the end of the battle, roll 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="25"/>
@@ -3762,7 +3762,7 @@ on the Exploration chart as long as the Hero who possesses this map was not take
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3810,7 +3810,7 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3867,7 +3867,7 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3892,7 +3892,7 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3999,4 +3999,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="811a-24be-dc66-b581" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Possessed.cat
+++ b/Possessed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="39bde8be-ab13-2d3c-098b-1d52b4cbbf63" name="Cult of the Possessed (1a)" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="39bde8be-ab13-2d3c-098b-1d52b4cbbf63" name="Cult of the Possessed (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Beastmen" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -122,7 +122,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -175,7 +175,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -310,7 +310,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -363,7 +363,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -510,7 +510,7 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -550,7 +550,7 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -692,7 +692,7 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -732,9 +732,9 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -879,7 +879,7 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -918,8 +918,8 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1095,9 +1095,9 @@ They automatically pass any Leadership tests they are required to take.</descrip
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1136,7 +1136,7 @@ They automatically pass any Leadership tests they are required to take.</descrip
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -4068,4 +4068,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="4264-0dfd-b858-0ccf" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Reikland_Mercenaries.cat
+++ b/Reikland_Mercenaries.cat
@@ -1,101 +1,101 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ac1721e2-653d-e279-11e3-ca8ba77b0637" name="Reiklanders (1a)" revision="9" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="https://github.com/BSData/mordheim/issues" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ac1721e2-653d-e279-11e3-ca8ba77b0637" name="Reiklanders (1a)" revision="10" battleScribeVersion="2.03" authorUrl="https://github.com/BSData/mordheim/issues" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Champion" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="2" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="78441028-11bf-6e67-5d4e-8ac796b2cea9" name="Champion" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -113,175 +113,175 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4c359fa9-8570-3c9d-56b9-c03be92aa0f6" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a1391776-47ea-0568-037f-ec8f44d71045" name="Serious Injuries" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ab0d5c14-996b-9379-7070-817be5b9161a" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup">
+            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases">
               <modifiers>
-                <modifier type="increment" field="minSelections" value="0.0"/>
+                <modifier type="increment" field="minSelections" value="0"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9f7d41cd-13db-b929-0b5e-8b2cfbe8ca02" name="Skills" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="67b818c7-d67c-76c1-3c50-aaf2384cb102" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="67b818c7-d67c-76c1-3c50-aaf2384cb102" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="a7d4eb84-400b-29e8-339c-fceebcba1553" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd77-2743-69a9-e466" type="min"/>
+            <constraint field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd77-2743-69a9-e466" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="35"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Marksmen" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7b6-6b20-4143-03ee" type="max"/>
+        <constraint field="selections" scope="roster" value="7" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7b6-6b20-4143-03ee" type="max"/>
       </constraints>
       <profiles>
         <profile id="03db3be8-cefc-ad94-7afb-227b97cb7434" name="Marksman" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -299,73 +299,73 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="38f17f5d-5cb6-91b3-1e1a-97d8f3eb211e" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="013f9186-66c1-6305-f439-f00681e1eba3" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9ce30996-6a67-3dc9-7f10-0cef9367edfb" name="Serious Injuries" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6c891bb7-ea61-b861-205b-c6c2af3abbc5" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="6c891bb7-ea61-b861-205b-c6c2af3abbc5" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dbbaea99-4e42-9338-962d-f21b14fc9dae" name="Skills" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -374,106 +374,106 @@
         <entryLink id="f57b6a1f-5d40-44cc-70b1-45f6d23525c3" name="Promoted" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="25.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="25"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83acbe09-ec66-c45c-0f5b-1a9e0017016e" name="Mercenary Captain" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="9bad7e19-0288-3d5d-12cf-efdc8815570d" name="Capitain" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -494,197 +494,197 @@
         <infoLink id="897a9a6b-fbef-690f-78d8-886616cbbe22" name="Leader" hidden="false" targetId="e23bd4fb-c553-13cf-2ab8-252167663a44" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a359fe11-ad97-3216-79e2-42fa0fcef557" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="56248f6d-5ee0-e166-254d-f40501f26f09" name="Serious Injuries" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a9874b15-5410-29f0-f05c-e629500fc5f5" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5d5c6559-2773-1cc5-3835-0eb5869758f2" name="Skills" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="9e2cb516-6834-4a3e-ec39-9855b3d6ed2d" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfcf-3b8e-7bb6-7d92" type="min"/>
+            <constraint field="selections" scope="parent" value="20" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfcf-3b8e-7bb6-7d92" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="60.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="60"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83ade99f-e9ef-d25a-59ac-ca3f3def011c" name="Stash" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true" name="Stash"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9045-0d3c-9631-a916" name="Wyrdstone" hidden="false" collective="false" import="true" type="upgrade">
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" name="Equipment" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="16763088-15c1-4f72-fdfe-153003be4a24" name="Swordsmen" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5143-08f2-0874-2088" type="max"/>
+        <constraint field="selections" scope="roster" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5143-08f2-0874-2088" type="max"/>
       </constraints>
       <profiles>
         <profile id="c28d122f-8919-90c6-7469-fc97ffa650c7" name="Swordsmen" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="16763088-15c1-4f72-fdfe-153003be4a24" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -702,83 +702,83 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="579963c2-b42f-2254-f6e0-c4746cd13fc4" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5dfc9f4e-4a13-6419-31a3-65479d1ab46e" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="61fbc53a-b34a-3545-2c0f-d54024540368" name="Serious Injuries" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="88dd0e95-e38e-5fb1-b06d-fe8ab07b0f41" name="Skills" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="ead51f82-ca51-5519-9a8a-b462449cf11d" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="3ace7cec-b98a-8120-c6ce-caf458afb673" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="ead51f82-ca51-5519-9a8a-b462449cf11d" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
+        <entryLink id="3ace7cec-b98a-8120-c6ce-caf458afb673" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="35"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="889151de-4826-5f00-5dbb-fcf546ebedbb" name="Warriors" page="0" hidden="false" collective="false" import="true" type="model">
@@ -787,92 +787,92 @@
           <modifiers>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -890,180 +890,180 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ffab3949-b7e7-0463-5c47-b05ae207fdbd" name=" Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="95dc4d07-7bf0-82ff-00a2-18a4c7c6aa7a" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="95dc4d07-7bf0-82ff-00a2-18a4c7c6aa7a" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8f929bbc-17ae-43e0-5c50-b9f170b8fbae" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9a736f7c-0a1a-2561-68bc-36da58b28c84" name="Serious Injuries" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c015fc99-0af0-e3a8-7f2a-85178866327b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="c015fc99-0af0-e3a8-7f2a-85178866327b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="63218ed0-c131-966a-df37-be55d3e983cf" name="Skills" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="68dfc5ad-72e4-3e81-2e9e-f6abd37596a9" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="2c761416-6f59-1a4f-2742-25e90f596c03" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="68dfc5ad-72e4-3e81-2e9e-f6abd37596a9" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
+        <entryLink id="2c761416-6f59-1a4f-2742-25e90f596c03" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="25.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="25"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" name="Youngblood" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="2" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="2bb25071-df94-bc53-5557-fd2deccf25d4" name="YoungBloods" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -1081,74 +1081,74 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7daa68c-56da-e5c0-ff61-454d0e70fc3a" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="04fe2754-4270-2490-96f1-ab3b718bec62" name="Serious Injuries" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6874fd6e-a707-b236-686b-975e3425b3f2" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e486a1eb-1be8-c547-e111-cf507ef97a76" name="Skills" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
+            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <modifiers>
-            <modifier type="set" field="minSelections" value="0.0"/>
+            <modifier type="set" field="minSelections" value="0"/>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="15.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="15"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -1167,168 +1167,168 @@ All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruit
   <sharedSelectionEntries>
     <selectionEntry id="8acf5ee1-3430-be22-ec94-15b12e15e497" name="+1 A" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e03b263-c206-09f3-f9d3-47c0c9294235" name="+1 BS" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0cbce569-483e-fc61-9a46-75bb7f52573a" name="+1 I" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6a2720c-06c4-d495-d8e5-0eeb2009570a" name="+1 LD" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="492ef626-87b8-7b39-378d-38fbd1ffb131" name="+1 M" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="62be0dba-2c77-76b0-3da3-48c05611f170" name="+1 S" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" name="+1 T" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a3c87526-fae5-8945-97c3-057d97df69e7" name="+1 W" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" name="+1 WS" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="06c6e571-9da5-51a2-4053-aeca9035e1a2" name="-1 A" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a93c5e1e-9169-8d09-5cba-5aa094184fe1" name="-1 BS" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" name="-1 I" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="043d62b3-76f8-822e-3d67-9c3806889918" name="-1 LD" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bf7c1f26-0442-54db-cacc-44dc499dcebc" name="-1 M" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" name="-1 S" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" name="-1 T" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bbd9ff4c-4aa7-432d-a143-b786400cef79" name="-1 W" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="abc4f440-9124-351f-831d-aaf5be4d3ae4" name="-1 WS" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f0fc009a-7990-32ef-b84b-b631058620e2" name="Experience" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="1.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="1"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b39ee84c-3f79-227e-4b39-8469fb19d56a" name="Gold" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="1.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="1"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0f2c78d6-e019-6b88-136a-9e00031645e5" name="Promoted" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" name="Academic Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="06d395bb-92a1-0ef9-339a-24781d43a616" name="Sorcery" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="ca2f0786-aaea-3f19-9f88-79fa24190fc3" name="Sorcery" page="0" hidden="false">
@@ -1336,13 +1336,13 @@ All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruit
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b70a36b7-25ec-9343-6e1e-b5896a0bce60" name="Battle Tongue" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="d5543d40-504a-8a9c-1834-9fb4480270ac" name="Battle Tongue" page="0" hidden="false">
@@ -1350,13 +1350,13 @@ All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruit
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7a4d4eec-5263-6896-1314-34c1a9265763" name="Streetwise" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="4bc58fa0-c8e1-8c7a-4608-d0d521dc245f" name="Streetwise" page="0" hidden="false">
@@ -1364,13 +1364,13 @@ All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruit
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a8550f60-6b54-e8b5-0404-edd81d0a94fd" name="Haggle" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="f24c33d6-eaba-c2f1-1489-17fcf5141a24" name="Haggle" page="0" hidden="false">
@@ -1378,13 +1378,13 @@ All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruit
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f90e4f05-f298-df4a-320a-e6354978048b" name="Arcane Lore" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="edcde1a4-663c-7c48-35e9-6c48b22fb8f4" name="Arcane Lore" page="0" hidden="false">
@@ -1392,13 +1392,13 @@ All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruit
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d45a55a3-6a34-e15e-4c2a-596621c66558" name="Wyrdstone Hunter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="467a2ef9-d383-5d6f-8359-58bde733f4e8" name="Wyrdstone Hunter" page="0" hidden="false">
@@ -1407,13 +1407,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="59ff18a1-758c-d172-a2ee-9831fe13e548" name="Warrior Wizard" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="1c9f51c4-f720-6acb-d802-769f62149251" name="Warrior Wizard" page="0" hidden="false">
@@ -1421,22 +1421,22 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" name="Armor" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="bd144faf-2ee7-d967-947b-e411ac750901" name="Light Armor" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1449,8 +1449,8 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="20"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dca0ad0f-ab8a-6fe8-18cc-6b207a23e8c5" name="Heavy Armor" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1463,8 +1463,8 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="50.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="50"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="57d232c8-f782-bb72-4d7c-222332e93e51" name="Helmet" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1477,11 +1477,11 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule"/>
+            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule" name="Avoid stun"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8937e866-bd85-b101-3b07-7e552038c9a2" name="Shield" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1494,8 +1494,8 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6980f8c9-e102-2440-30da-a10572cde567" name="Buckler" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1508,11 +1508,11 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="179351b1-b943-159c-70c0-5328a17a363b" name="Barding" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1525,11 +1525,11 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
+            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="80.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="80"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97262f51-4a0b-7127-c03a-9499e7e38a0a" name="Gromril Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1537,13 +1537,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             <profile id="9198fa07-1c51-4b16-db0f-a40e4cdb47f2" name="Gromril Armour" page="0" hidden="false" typeId="94239014-ea28-23eb-4142-f492dc4caf17" typeName="Armor">
               <characteristics>
                 <characteristic name="Armor Save" typeId="26f1ea4e-6017-a8fa-db2b-5c2a83aea46b">4+</characteristic>
-                <characteristic name="Special" typeId="ff797ec4-8d7e-cab1-656e-896ae3ed005f">Not Showed By Shield </characteristic>
+                <characteristic name="Special" typeId="ff797ec4-8d7e-cab1-656e-896ae3ed005f">Not Showed By Shield</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="150.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="150"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c5858e9f-c606-bb70-93af-8a7d6cde63e7" name="Ithilmar Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1556,73 +1556,73 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="90.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="90"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="f42ac18f-5b17-105f-54fa-9b8a3c426954" name="Characteristic Decreases" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry"/>
-        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry"/>
-        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry"/>
-        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry"/>
-        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry"/>
-        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry"/>
-        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
-        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry"/>
-        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry"/>
+        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I"/>
+        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry" name="-1 S"/>
+        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS"/>
+        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS"/>
+        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T"/>
+        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry" name="-1 A"/>
+        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
+        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry" name="-1 LD"/>
+        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry" name="-1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="36e117d8-419f-59b9-e337-512db3c6c990" name="Characteristic Increases" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry"/>
-        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry"/>
-        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry"/>
-        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry"/>
-        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry"/>
-        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry"/>
-        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
-        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry"/>
-        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry"/>
+        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry" name="+1 I"/>
+        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry" name="+1 S"/>
+        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry" name="+1 WS"/>
+        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry" name="+1 BS"/>
+        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry" name="+1 T"/>
+        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry" name="+1 A"/>
+        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry" name="+1 M"/>
+        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry" name="+1 LD"/>
+        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry" name="+1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bd8689c9-bc5c-df7b-87b9-aad34e27a295" name="Combat Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="ce9199d6-76a7-4a61-a2f7-1c455f85f7ff" name="Step Aside" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="5eec59a7-d70a-6aca-53f1-0bb0aa6f2f28" name="Step Aside" page="0" hidden="false">
@@ -1630,13 +1630,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eca4795b-79e1-a9cf-8b0c-c45720e58eba" name="Strike To Inure" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="b0873110-394b-caf5-ff51-10d504987872" name="Strike To injure" page="0" hidden="false">
@@ -1644,13 +1644,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="711fe0b5-ee48-771c-9fb3-4334ea4ea04b" name="Expert Swordsman" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="febd00dc-6add-2876-cd50-adfe163fc4b6" name="Expert Swordsman" page="0" hidden="false">
@@ -1659,13 +1659,13 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d874e48b-2d36-f775-deb3-0e4db17c67c9" name="Web Of Steel" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="7a1dcc12-4bc8-c8be-6c15-66e1584f0973" name="Web Of Steel" page="0" hidden="false">
@@ -1673,13 +1673,13 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d35ac8d5-1a70-5c1c-e4a1-cc2d819e62aa" name="Weapons Traning" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="6799f229-089c-bc70-ecb5-a16d3f4a21a3" name="Weapons Traning" page="0" hidden="false">
@@ -1687,13 +1687,13 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97106b1b-3866-90a6-0521-c6b6d794a6fe" name="Combat Master" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="90c9b94a-4eb7-cda4-fb71-3808b78043fd" name="Combat Master" page="0" hidden="false">
@@ -1701,40 +1701,40 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="50dfad7a-35b1-bee6-657c-d603b181977d" name="Equipment" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
-        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
-        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
+        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
+        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup" name="Missile Weapons"/>
+        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup" name="War Gear"/>
+        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="0c67e100-6cf2-2342-3af1-6445f5a163c9" name="Dagger" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1747,43 +1747,43 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="a022bf96-d456-1fd8-41e6-fd0882f5ed93" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="6.0"/>
+                <modifier type="set" field="points" value="6"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db350a56-7488-0569-a892-70cea870a2a4" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="4.0"/>
+                <modifier type="set" field="points" value="4"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="2"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="467a0329-1c84-acb1-b68f-495561849ac2" name="Axe" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1798,38 +1798,38 @@ only applies when they are armed with normal swords or weeping blades, and not w
           <selectionEntries>
             <selectionEntry id="5f8a42fc-4bd6-10d7-cd86-1a436766e50e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="15.0"/>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5694af16-4f26-7ece-b0af-6d8ec0b0548d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="10.0"/>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1efe5bb0-e06e-526f-e580-983a8da4b54e" name="Morning Star" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1842,44 +1842,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule"/>
+            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule" name="Difficult to use"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="37972d57-6f98-64fc-0e7c-cc3c30174a11" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="45.0"/>
+                <modifier type="set" field="points" value="45"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fa8afbe-87f0-7dfe-566f-bf7c03e5a08c" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6b5ce748-913b-065d-6a34-5639d9a94b3d" name="Sword" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1892,43 +1892,43 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="fcc1d76e-a482-00a0-03fb-fecd9deb538e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e954ffd3-9cf2-a93b-6362-2c1c76a6c6b9" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fe26dc5f-994d-51e3-f2da-34fbf40ffb8a" name="Double Handed Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1941,44 +1941,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule"/>
-            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule" name="Strike Last"/>
+            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="eafc9bba-c5a2-09d3-627c-c5c102a70528" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="45.0"/>
+                <modifier type="set" field="points" value="45"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c55ad349-89d8-aabe-619d-d334481460c0" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c9494475-3720-3676-42b0-8a7c261ae004" name="Spear" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1991,45 +1991,45 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule"/>
-            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule"/>
-            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule" name="Strike First"/>
+            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule" name="Unwieldy"/>
+            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="3ef9bbbf-a875-133e-a275-fb47750ca7d8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f737ba7-658d-f833-131c-48735ada0760" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5f0e7a6b-e633-9b8e-d06a-fb5c82e885b9" name="Halberd" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2042,48 +2042,48 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="e1ae1bcf-84ef-dd9f-ae28-ed867c321df4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e625c4af-e133-1445-41fe-f9b23e142828" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8eed780c-18dd-ae9e-70a2-047fdd644c7b" name="Free Dagger" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <profiles>
             <profile id="c419d855-1a49-a967-4b92-d910d59fd87b" name="Free Dagger" page="0" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
@@ -2094,11 +2094,11 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e58cd147-18f5-e468-6077-679bc48de6c6" name="Club,Mace, Hammer" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2111,43 +2111,43 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule"/>
+            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule" name="Concussion"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="0608e581-cb18-48b9-ab15-a1c7143f9203" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="9.0"/>
+                <modifier type="set" field="points" value="9"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="14736779-2638-2e8d-aa0e-d8eba9ac62da" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="6.0"/>
+                <modifier type="set" field="points" value="6"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="3.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="3"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dfbc868a-c6a4-80ae-2c3a-1789b3dde6dd" name="Fist" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2160,11 +2160,11 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="46a156bc-9d62-8bf1-94aa-26ed5a1cad42" name="Flail" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2177,44 +2177,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="aaef08ab-959e-c1cb-cce3-c9409cfc73c2" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="45.0"/>
+                <modifier type="set" field="points" value="45"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="287e8d26-b5e0-f724-72af-a96a7d60dd9f" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7b8b4f8a-d2bc-1564-a447-a5bd22994f8a" name="Lance" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2227,44 +2227,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule"/>
-            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule" name="Cavalry Weapon"/>
+            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="50469495-65e4-8313-fb4a-b47e3f3d4e5d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="120.0"/>
+                <modifier type="set" field="points" value="120"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9672b2b9-bd40-6d29-3481-03cc43fc620d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="80.0"/>
+                <modifier type="set" field="points" value="80"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="40"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d5b77a74-af16-76e5-a643-97b6d31673c5" name="Ball and Chain" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2278,9 +2278,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
           </profiles>
           <rules>
             <rule id="864c3646-5890-c82c-6ee7-bbffb4450668" name="Incredible Force" page="0" hidden="false">
-              <description>No armour saves are allowed against wounds caused by a Ball and Chain and any hit that successfully wounds will do 1D3 wounds instead of 1
-
-</description>
+              <description>No armour saves are allowed against wounds caused by a Ball and Chain and any hit that successfully wounds will do 1D3 wounds instead of 1</description>
             </rule>
             <rule id="9e707917-73d2-ca7b-e3ec-590a01e1a38b" name="Random:" page="0" hidden="false">
               <description>The first turn he starts swinging the Ball and Chain, the model is moved 2D6&quot; in a direction nominated by the controlling player. In his subsequent Movement phases, roll a D6 to determine
@@ -2296,9 +2294,7 @@ Opponents wishing to attack a Ball and Chain wielding model suffer a To Hit pena
 
 The Ball and Chain wielder cannot be held in close combat and will automatically move even if h e starts the Movement phase in base contact with another model. If the model moves into contact with a building, wall, or other obstruction, he is automatically taken out of action.
 
-ignores the special rules for Animosity.
-
-</description>
+ignores the special rules for Animosity.</description>
             </rule>
             <rule id="a2948139-cad2-7570-b3cf-8f995b16961d" name="CumbersomE" page="0" hidden="false">
               <description>a model equipped with one may carry no other weapons or equipment, only Mad Cap Mushrooms which they must have.</description>
@@ -2308,22 +2304,22 @@ ignores the special rules for Animosity.
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="38175608-757c-9eb5-59a8-2f7b6b1019e2" name="Missile Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="1d6b2c12-9dac-3bd9-d347-474ae54769a9" name="Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2337,8 +2333,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="be4e70ce-f2a1-8dfa-9035-058eb1c95243" name="Cross Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2352,8 +2348,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="25"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f2c1760d-e4f4-8d3a-fcda-84379e0b3aca" name="Short Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2367,8 +2363,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e7ec5cd8-4ff0-f9b7-60a4-11d73a62708f" name="Blunderbuss" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2382,8 +2378,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="11a5f8ff-a6da-82cd-a638-423e3892d66f" name="Crossbow Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2397,8 +2393,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="35"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="21769e56-0db7-859a-95df-be7e48c3ab13" name="Dueling Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2422,12 +2418,12 @@ a duelling pistol have a +1 bonus to hit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
-            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
+            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Firearm save modifier"/>
+            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0d41d311-b3bc-ac40-3094-2aadf128c780" name="Elf Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2441,11 +2437,11 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="35"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8f320f8f-a366-6288-2f18-f74708b6a407" name="Hand Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2459,13 +2455,13 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
-            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule"/>
-            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
+            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
+            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule" name="Move or fire"/>
+            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Firearm save modifier"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="35"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="51e5c18d-d32f-15f8-e231-cd527cbc9194" name="Long Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2479,14 +2475,14 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ecb7edf4-93de-d2c6-0853-c960bcf065c8" name="Hunting Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <costs>
-            <cost name="pts" typeId="points" value="200.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="200"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a3d6e341-41b1-b147-933d-a7f25b6219a7" name="Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2506,8 +2502,8 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="09822e77-d1ec-85ad-3d31-643311e268a9" name="Repeater Crossbow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2521,8 +2517,8 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="40"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="70472c5d-bf97-753a-2b8c-3f1a54c6abff" name="Sling" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2536,8 +2532,8 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="2"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2582db34-2deb-3752-0e9a-8a309edbcfaa" name="Throwing Knives/stars" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2551,22 +2547,22 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="2ace8f8f-6f26-2b7f-5407-332ed11d0355" name="Serious Injuries" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="78aa00f9-ee2f-2482-1090-4d1ca59a8169" name="Leg Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2576,15 +2572,15 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="235f320e-f3a2-d485-4769-0b8a2a88fcf7" name="Severe Arm Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2594,26 +2590,26 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d7277e6e-49d8-50cb-988c-84bb7240da31" name="Maddness: Stupidity" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
+            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="abc70d10-8ad7-23a1-6eb0-e05474350e3f" name="Madness: Frenzy" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule"/>
+            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule" name="Frenzy"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8902fa66-7b19-ed57-c029-35c34cd7efe2" name="Chest Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2623,15 +2619,15 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dbccc133-7061-c16e-eb8b-ab7a378c418c" name="Blind In one Eye" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2642,15 +2638,15 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry">
+            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="213d3373-4b14-d558-fe3d-370cd420bb47" name="Old Battle Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2660,8 +2656,8 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="569e02f1-7179-556f-8824-1219b3c42902" name="Nervous Condition" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2671,15 +2667,15 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fe54554d-0e2c-9a33-6a50-a38ce16ea71c" name="Hand Injury" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2689,15 +2685,15 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="862a6b8f-fd65-9fec-da82-a1791ff77f8f" name="Bitter Emity" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2707,8 +2703,8 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4dab123f-803f-dc5f-ea99-5ea87ae20681" name="Hardened" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2718,8 +2714,8 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cf7e9bf2-6643-1719-c87b-61b79f7ae434" name="Horrible Scars" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2729,11 +2725,11 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="732f7f66-fdb2-5421-a06e-a18e90e6d9b8" name="Smashed Leg" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2743,27 +2739,27 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="52007ee0-cc99-b312-3650-cfab391e476c" name="Shooting Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="6e412341-cfdd-1cd2-9617-89e1db80a649" name="Trick Shooter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="75f5f275-f326-d555-5d4d-9603b968e777" name="Trick Shooter" page="0" hidden="false">
@@ -2771,13 +2767,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2f78e9cf-083b-de60-5dc6-aa4693f93662" name="Nimble" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="888f9ab7-efac-8b9a-4b64-350d27d109be" name="Nimble" page="0" hidden="false">
@@ -2785,13 +2781,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b4628d7b-54f0-007e-d857-88008b63adb7" name="Weapons Expert" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="72827526-238a-8f4c-1a63-f41c6660cf21" name="Weapons Expert" page="0" hidden="false">
@@ -2799,13 +2795,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="feecb448-3528-78fa-b91a-56c7821587ad" name="Eagle Eyes" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="2b06b2d4-b8c7-8e2b-6528-97de32d06b19" name="Eagle Eyes" page="0" hidden="false">
@@ -2813,13 +2809,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1fa884e8-d2d8-3118-188b-98cb1a3d1565" name="Pistolier" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="481962a4-f659-388b-9fde-1496c2ceba00" name="Pistolier" page="0" hidden="false">
@@ -2827,13 +2823,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e61270fc-7700-33cc-ec95-f0f5941833fd" name="Quick Shot" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="cec15b88-d45b-8f95-b041-8061a0391747" name="Quick Shot" page="0" hidden="false">
@@ -2842,13 +2838,13 @@ with a bow or crossbow (but not a crossbow pistol).</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5ab33d02-0d99-fc8b-5058-3f6c957d5744" name="Hunter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="f7e02dac-a51f-7e27-82ad-22132555bef5" name="Hunter" page="0" hidden="false">
@@ -2856,13 +2852,13 @@ with a bow or crossbow (but not a crossbow pistol).</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ece8f370-6d96-5508-c75e-e469e3290a13" name="Knife Fighter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="aaa7e060-2bb3-354c-31a6-332a8b5fe961" name="Knife Fighter" page="0" hidden="false">
@@ -2870,95 +2866,95 @@ with a bow or crossbow (but not a crossbow pistol).</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="39deaab7-93cc-922b-d866-f7368e56495a" name="Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="0270-ae38-3bb3-6fc2" name="Academic Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9724-5195-69bb-05e6" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9724-5195-69bb-05e6" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="0d4c-6cb4-d3e6-adfd" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c284-2f63-180e-050a" name="Combat Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f3-49de-f813-4cd2" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f3-49de-f813-4cd2" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="7cc9-0386-10ed-c990" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eefd-8387-5f1c-0dd5" name="Shooting Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adca-cca1-7b3e-e955" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adca-cca1-7b3e-e955" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="25e4-c6cb-36e4-b416" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d673-3854-b15b-b4ba" name="Speed Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c34-7423-5b15-6022" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c34-7423-5b15-6022" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="53dd-a9a1-d32b-2d13" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f010-bc79-3293-d469" name="Strength Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="072e-ef1a-4114-6fc5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="072e-ef1a-4114-6fc5" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="aac9-3a0e-c654-9b1a" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="2a62fe9a-16ae-b087-f5a5-47f19da37c89" name="Speed Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="3bb65cd7-5c4f-3f18-0a1c-85922b7bdef4" name="Scale Sheer Surfaces" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="4319dae5-face-906e-debf-19997db0f5b7" name="Scale Sheer Surfaces" page="0" hidden="false">
@@ -2967,13 +2963,13 @@ Movement, and does not need to make Initiative tests when doing so</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aa16dd2b-9873-72e9-fb25-8a9a697cc0ce" name="Dodge." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="559cda8e-dd5a-62c3-3c11-99e5a3c30d92" name="Dodge." page="0" hidden="false">
@@ -2981,13 +2977,13 @@ Movement, and does not need to make Initiative tests when doing so</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d88227c5-0c1b-7885-1435-67180bef016b" name="Jump Up" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="0f0ad3a6-9367-7873-55f8-c4ad0fdbe589" name="Jump Up" page="0" hidden="false">
@@ -2996,13 +2992,13 @@ wearing a helmet or because he has the No Pain special rule.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a35f147f-18b0-8304-0632-3d90a8aeb38b" name="Lightning Reflexes" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="fb1ac65f-7bc6-e64f-b7f3-4bae70bee33b" name="Lightning Reflexes" page="0" hidden="false">
@@ -3011,13 +3007,13 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0dc47a72-5378-9081-f141-3f8b5274f93a" name="Acrobat." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="a457974b-633e-a34c-18dc-58cf502f56b3" name="Acrobat" page="0" hidden="false">
@@ -3025,13 +3021,13 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="81c10a39-89d1-a85b-6d03-8fdde521ca0f" name="Leap" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="f464099c-a8d5-e6c3-832e-90607f3760a6" name="Leap" page="0" hidden="false">
@@ -3039,13 +3035,13 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5a8c0670-333b-f6e4-63aa-95f3809481e8" name="Sprint." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="cebba0f2-2f4b-5f1c-3101-08f082e40338" name="Sprint" page="0" hidden="false">
@@ -3053,27 +3049,27 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="9e76820a-3a93-f94a-a7c7-d31889583e06" name="Strength Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="5925429b-e4f5-6ffb-e14a-15bed5241afc" name="Mighty Blow" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="d940b4ab-2ac6-b296-48af-dbadc6b8689e" name="Mighty Blow" page="0" hidden="false">
@@ -3082,13 +3078,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6c5bd831-8cd8-838f-8d35-0c829ee6397e" name="Pit Fighter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="97f6f469-30e7-bd9f-0281-d44b19568bbb" name="Pit Fighter" page="0" hidden="false">
@@ -3096,13 +3092,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="499e0aa5-1296-7a29-5ae5-a1d38c7c654e" name="Resilient" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="78cdf4f5-0561-39da-c3f3-82000a40a2b3" name="Resilient" page="0" hidden="false">
@@ -3110,13 +3106,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1d15d220-4d5d-c25e-f9cc-6c82d54aaf24" name="Fearsome" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="bad193e4-5b8d-9b6b-6b5c-f9f3082572c9" name="Fearsome" page="0" hidden="false">
@@ -3124,13 +3120,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="82d80676-7114-6b28-82b1-5851133d1dca" name="Strongman" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="4300f1bc-89a1-6955-5b97-f8a81f0b5b27" name="Strongman" page="0" hidden="false">
@@ -3138,13 +3134,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e5248876-9211-cad5-5cc5-de5860de56c4" name="Unstoppable Charge" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="40b60f97-ac19-e6e0-70e6-4d655694d095" name="Unstoppable Charge" page="0" hidden="false">
@@ -3152,22 +3148,22 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="cd413ae9-4927-5bae-ff6e-93723ba44113" name="War Gear" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="79c9c680-da5e-78c9-9e6b-1360200cd213" name="Black Lotus" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3177,11 +3173,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6d926a98-4656-9782-cf2c-c6d7c8cfce52" name="Blessed Water" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3191,11 +3187,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4fc7ded6-c534-1735-fc46-0a68de7f5874" name="Bugman&apos;s Ale" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3205,11 +3201,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b666f570-da7b-8f8f-f63f-30dfcce33708" name="Cathayan Silk Clothes" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3219,11 +3215,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9598e4dd-04e8-d1f8-c25d-9e286ec1f3ed" name="Crimson Shade" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3236,11 +3232,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bcbc3583-cebe-ae6c-1613-0530f1f83d5d" name="Dark Venom" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3250,11 +3246,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1cafb109-3ed9-1b35-8c05-05a37ca5270e" name="Elven Cloak" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3264,11 +3260,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="100.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="100"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a2c3293d-3403-3549-2eea-c0b1be66566a" name="Garlic" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3278,8 +3274,8 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="1.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="1"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6665a576-6dbb-daa9-61a5-277abb2db97c" name="Halfling Cook Book" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3289,11 +3285,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="90e94c9a-b505-0d4a-e34b-3284ba64ffbe" name="Healing Herbs" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3303,11 +3299,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="20"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="608c9528-a785-cc65-f601-e31db8e08f00" name="(un)Holy Relic" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3317,11 +3313,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="76574461-1664-c71d-acbd-e0a471d2d2bb" name="Holy Tome" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3331,11 +3327,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="42ea245f-22f1-7cf0-ac6e-480d76e6d90e" name="Horse" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3361,8 +3357,8 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="40"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cd2b60e4-33cf-3441-ac05-b26aff4cc568" name="Hunting Arrows" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3372,11 +3368,11 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ff424c20-67c1-a8be-4db3-6fce5c831c33" name="Lantern" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3386,8 +3382,8 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="68ca3356-bc30-b017-dd79-86d700958a24" name="Lucky Charm" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3397,8 +3393,8 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="23b12fc8-765a-f41b-12d8-94746abb37f3" name="Mad Cap Mushrooms (Orcs)" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3411,8 +3407,8 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="25"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="444ae29c-bd6b-e577-1aa2-05375176ede4" name="Mandrake Root" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3424,11 +3420,11 @@ Side effects: Mandrake Root is highly poisonous. At the end of the battle, roll 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="25"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b8fcbd86-29d9-ffb3-bb41-1ca6d75d9c17" name="Mordhiem Map" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3452,11 +3448,11 @@ on the Exploration chart as long as the Hero who possesses this map was not take
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7c7981cc-3051-0886-b1ad-69f7e7057323" name="Net" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3467,8 +3463,8 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1053cb3f-c81c-325f-71c3-9cd65320a3f2" name="Rope And Hook" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3478,19 +3474,19 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="50fdf0ff-9749-00e2-6814-f22ca69ba575" name="Superior Black Powder" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
             <rule id="c19c8a90-8410-47be-49c1-1a4295ce3ae8" name="Superior Black Powder" page="0" hidden="false">
-              <description> +1 Strength to all blackpowder weapons that the model has. There is enough superior blackpowder to last for one game.</description>
+              <description>+1 Strength to all blackpowder weapons that the model has. There is enough superior blackpowder to last for one game.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ea883376-5b97-5986-5ca6-c9d12fc0b66c" name="Tome Of Magic" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3500,11 +3496,11 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bfa7d5e5-4f28-52d9-eea1-cf2855b1f039" name="Warhorse" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3530,8 +3526,8 @@ You may mount one of your Heroes on a warhorse in the coming battles. Warhorses 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="80.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="80"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0eccb01c-3cd1-b1c6-edef-de00b04e67df" name="Wardog" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3557,11 +3553,11 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fb90c61e-63c8-ee98-05b2-afb1f4aae1d8" name="Squigg Prodder" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3571,8 +3567,8 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4bd08e4d-f4aa-d1ca-5f07-a33d57dd2c29" name="Mad Cap Mushrooms" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3585,11 +3581,11 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d4e0b60e-c797-a04d-6f7a-20c38cc6c1ce" name="Tears of Shallaya" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3599,11 +3595,11 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3627,7 +3623,7 @@ result as knocked down instead. This save is not modified by the opponent’s St
       <description>Hammers and other bludgeoning weapons are excellent to use for striking your enemy senseless. When using a hammer, club or mace, a roll of 2-4 is treated as stunned when rolling to see the extent of a model’s injuries.</description>
     </rule>
     <rule id="6118263e-03c4-68f7-694d-6ceebac4e80b" name="Cutting edge" page="0" hidden="false">
-      <description> A Cutting edgee has an extra save modifier of -1, so a model with Strength 4 using an Cutting edge has a -2 save modifier when he hits an opponent in hand-to-hand combat.</description>
+      <description>A Cutting edgee has an extra save modifier of -1, so a model with Strength 4 using an Cutting edge has a -2 save modifier when he hits an opponent in hand-to-hand combat.</description>
     </rule>
     <rule id="140e74d1-bf16-356b-c7d1-08b3bb5052b5" name="Difficult to use" page="0" hidden="false">
       <description>A model with a Difficult to use weapon  may not use a second weapon or buckler in his other hand because it requires all his skill to wield it. He may carry a shield as normal though.</description>
@@ -3648,7 +3644,7 @@ Attacks have 4, etc. If a warrior is carrying a weapon in each hand, he receives
 no longer frenzied. He continues to fight as normal for the rest of the battle.</description>
     </rule>
     <rule id="6549136a-9a00-4d3a-b8fa-ecadf63e4744" name="Gromril weapon" page="0" hidden="false">
-      <description>A gromril weapon has an extra -1 save modifier, and costs four times the price of a normal weapon of its kind. </description>
+      <description>A gromril weapon has an extra -1 save modifier, and costs four times the price of a normal weapon of its kind.</description>
     </rule>
     <rule id="a3327e94-8ff2-b189-9303-34c54c57373f" name="Firearm save modifier" page="0" hidden="false">
       <description>This weapon is even better at penetrating armour than its Strength suggests. A warrior wounded by a firearm must make his armour save with a -2 modifier.</description>
@@ -3696,7 +3692,10 @@ combat, roll a D6.
       <description>model armed with a 2handed weapon may not use a shield, buckler or additional weapon in close combat. If the model has a shield he still gets a +1 bonus to his armour save against shooting.</description>
     </rule>
     <rule id="be37b096-f38b-d3f0-0c72-f18572a56f1d" name="Unwieldy" page="0" hidden="false">
-      <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon. </description>
+      <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="039a-11be-85a9-9664" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Sitsters_of_Sigmar.cat
+++ b/Sitsters_of_Sigmar.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c6b6bbc1-2d97-0206-16d1-5845aabffac4" name="Sisters of Sigmar (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="c6b6bbc1-2d97-0206-16d1-5845aabffac4" name="Sisters of Sigmar (1a)" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Augur" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -129,7 +129,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -317,8 +317,9 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
           <entryLinks>
             <entryLink id="7de5f8f9-b8fb-02db-1b9d-37658dd743e8" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
             <entryLink id="ffd3fea9-533a-d8fb-861e-c66a61197d55" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
-            <entryLink id="0b286487-3d73-3d5e-0541-d2aa37df2c11" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup" name="War Gear"/>
+            <entryLink id="0b286487-3d73-3d5e-0541-d2aa37df2c11" hidden="false" collective="false" import="true" targetId="a2cf-6f28-f7c2-275d" type="selectionEntryGroup" name="Miscellaneous Equipment"/>
             <entryLink import="true" name="Missile Weapons" hidden="false" id="832f-42f9-c5ed-0056" collective="false" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
+            <entryLink import="true" name="Miscellaneous Equipment (1a)" hidden="false" id="5ea7-7c5c-30d3-071b" type="selectionEntryGroup" targetId="27a7-c1bf-0c40-ff21"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -513,7 +514,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -718,7 +719,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -899,7 +900,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -986,7 +987,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup" name="Equipment"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -3796,4 +3797,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="5dbc-6b00-30ed-6980" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Sitsters_of_Sigmar.cat
+++ b/Sitsters_of_Sigmar.cat
@@ -172,8 +172,8 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
-            <entryLink id="5aa67ce9-a1e1-ee26-1cc2-bffe2ece0b54" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="5aa67ce9-a1e1-ee26-1cc2-bffe2ece0b54" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
             <entryLink id="cca9ff26-2136-3216-f89c-aa6462d85bd0" hidden="false" collective="false" import="true" targetId="bf3da9bd-6711-12b2-2e23-5167d3c0d321" type="selectionEntryGroup" name="Special Skills (sisters)"/>
           </entryLinks>
           <costs>
@@ -372,7 +372,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" name="Skills" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" name="Skills" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -553,10 +553,10 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
             <entryLink id="a4d21b71-da65-083f-8b7b-6dcea2064765" name="Special Skills (sisters)" hidden="false" collective="false" import="true" targetId="bf3da9bd-6711-12b2-2e23-5167d3c0d321" type="selectionEntryGroup">
               <entryLinks>
                 <entryLink id="7f4f-a89b-5e87-171d" name="Utter Determination" hidden="false" collective="false" import="true" targetId="03e9-6c94-af79-85a4" type="selectionEntry">
@@ -758,10 +758,10 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fbdb734f-6d02-6ffb-7c2d-d049890b9d2a" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="21e7d3d1-05d7-0b9c-b1c7-fa8c968e9706" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
-            <entryLink id="95424165-4d2b-dd42-411e-d7a6f0310c8f" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="734dbb6f-71cf-bebe-cb75-d051bf7f4bbc" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="fbdb734f-6d02-6ffb-7c2d-d049890b9d2a" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="21e7d3d1-05d7-0b9c-b1c7-fa8c968e9706" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="95424165-4d2b-dd42-411e-d7a6f0310c8f" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="734dbb6f-71cf-bebe-cb75-d051bf7f4bbc" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
             <entryLink id="6c55673c-b1e5-60ee-3d60-d7c44b3a42ef" hidden="false" collective="false" import="true" targetId="bf3da9bd-6711-12b2-2e23-5167d3c0d321" type="selectionEntryGroup" name="Special Skills (sisters)"/>
           </entryLinks>
           <costs>
@@ -953,7 +953,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" name="Skills" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" name="Skills" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -168,11 +168,11 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
             <entryLink id="e741c476-895b-58bb-be34-06c08766be8e" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
           </entryLinks>
           <costs>
@@ -348,11 +348,11 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
             <entryLink id="b2b5f6c5-41cb-2760-2e87-3b5b2bb4da8e" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
-            <entryLink id="b20a9347-f744-9dee-2bd1-678592b5cd60" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="b20a9347-f744-9dee-2bd1-678592b5cd60" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -531,9 +531,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
             <entryLink id="ca854aa3-83b2-c930-7f5f-feb0582be796" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
-            <entryLink id="be110a0b-bcd6-fba0-6d35-e38bcb0459a8" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="be110a0b-bcd6-fba0-6d35-e38bcb0459a8" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -897,9 +897,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="466318cd-1b4d-41ac-be05-ffe35e511c26" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="466318cd-1b4d-41ac-be05-ffe35e511c26" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
             <entryLink id="b5f0447a-c61d-c902-a24d-424ad25be42a" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
-            <entryLink id="cfcc91f5-b518-78e5-d939-f7225a8c60fc" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="cfcc91f5-b518-78e5-d939-f7225a8c60fc" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup" name="Shooting Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1382,7 +1382,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
+            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3344,7 +3344,7 @@ with a bow or crossbow (but not a crossbow pistol).</description>
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="e0a34910-f971-a9f6-2735-86e721bb904a" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+        <entryLink id="e0a34910-f971-a9f6-2735-86e721bb904a" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
         <entryLink id="fe0f976f-7e51-73d0-e9c4-ddb8c2facad4" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
         <entryLink id="5efa8246-ad2e-146b-67fe-b747a1c0cb22" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
         <entryLink id="41fcb00f-2237-9ca0-5b99-9f34f4e834e6" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="facb1142-7463-7676-00c0-d78150e13a50" name="Skaven (1a)" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="facb1142-7463-7676-00c0-d78150e13a50" name="Skaven (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="facb1142--pubN71023" name="Mordheim Official"/>
   </publications>
@@ -117,10 +117,10 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="897a9a6b-fbef-690f-78d8-886616cbbe22" hidden="false" targetId="e23bd4fb-c553-13cf-2ab8-252167663a44" type="rule"/>
+        <infoLink id="897a9a6b-fbef-690f-78d8-886616cbbe22" hidden="false" targetId="e23bd4fb-c553-13cf-2ab8-252167663a44" type="rule" name="Leader"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a359fe11-ad97-3216-79e2-42fa0fcef557" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -129,7 +129,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -142,7 +142,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -155,7 +155,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -168,12 +168,12 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
-            <entryLink id="e741c476-895b-58bb-be34-06c08766be8e" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="e741c476-895b-58bb-be34-06c08766be8e" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -182,7 +182,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="9e2cb516-6834-4a3e-ec39-9855b3d6ed2d" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="9e2cb516-6834-4a3e-ec39-9855b3d6ed2d" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <constraints>
             <constraint type="min" value="20" field="selections" scope="parent" shared="true" id="3ac-bde-9403-5ecc"/>
           </constraints>
@@ -300,7 +300,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7daa68c-56da-e5c0-ff61-454d0e70fc3a" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -309,7 +309,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -322,7 +322,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -335,7 +335,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -348,11 +348,11 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="b2b5f6c5-41cb-2760-2e87-3b5b2bb4da8e" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup"/>
-            <entryLink id="b20a9347-f744-9dee-2bd1-678592b5cd60" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
+            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="b2b5f6c5-41cb-2760-2e87-3b5b2bb4da8e" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
+            <entryLink id="b20a9347-f744-9dee-2bd1-678592b5cd60" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -361,7 +361,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <constraints>
             <constraint type="min" value="8" field="selections" scope="parent" shared="true" id="40bd-b0f5-ca55-e153"/>
           </constraints>
@@ -479,7 +479,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4c359fa9-8570-3c9d-56b9-c03be92aa0f6" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -488,7 +488,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -501,7 +501,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -514,7 +514,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup">
+            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases">
               <modifiers>
                 <modifier type="increment" field="minSelections" value="0"/>
               </modifiers>
@@ -531,9 +531,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="ca854aa3-83b2-c930-7f5f-feb0582be796" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup"/>
-            <entryLink id="be110a0b-bcd6-fba0-6d35-e38bcb0459a8" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="ca854aa3-83b2-c930-7f5f-feb0582be796" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
+            <entryLink id="be110a0b-bcd6-fba0-6d35-e38bcb0459a8" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -546,7 +546,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c6c891af-4aff-4d59-760e-68ab30e7249f" hidden="false" collective="false" import="true" targetId="e79d1530-e0da-1681-1b2a-f57bc2c48d13" type="selectionEntryGroup"/>
+            <entryLink id="c6c891af-4aff-4d59-760e-68ab30e7249f" hidden="false" collective="false" import="true" targetId="e79d1530-e0da-1681-1b2a-f57bc2c48d13" type="selectionEntryGroup" name="Magic of the Horned Rat"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -555,7 +555,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="a7d4eb84-400b-29e8-339c-fceebcba1553" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="a7d4eb84-400b-29e8-339c-fceebcba1553" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <constraints>
             <constraint type="min" value="8" field="selections" scope="parent" shared="true" id="e7a3-e21c-89a2-8361"/>
           </constraints>
@@ -663,7 +663,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ffab3949-b7e7-0463-5c47-b05ae207fdbd" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -672,7 +672,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="95dc4d07-7bf0-82ff-00a2-18a4c7c6aa7a" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="95dc4d07-7bf0-82ff-00a2-18a4c7c6aa7a" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -685,7 +685,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="0fedf584-057a-d5e9-d0ec-1a35de45e96c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -705,7 +705,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c015fc99-0af0-e3a8-7f2a-85178866327b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="c015fc99-0af0-e3a8-7f2a-85178866327b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -725,7 +725,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -734,8 +734,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="68dfc5ad-72e4-3e81-2e9e-f6abd37596a9" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
-        <entryLink id="2c761416-6f59-1a4f-2742-25e90f596c03" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
+        <entryLink id="68dfc5ad-72e4-3e81-2e9e-f6abd37596a9" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
+        <entryLink id="2c761416-6f59-1a4f-2742-25e90f596c03" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15"/>
@@ -849,7 +849,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9ca77bf6-d4b6-5676-7f61-5cbe7bfb78f8-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="9ca77bf6-d4b6-5676-7f61-5cbe7bfb78f8-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c26894fd-9c16-0b88-2e78-7b470c12ab46" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -858,7 +858,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0cb6067b-4f3b-147c-44ef-5653649cb204" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="0cb6067b-4f3b-147c-44ef-5653649cb204" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -871,7 +871,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a814a289-0d8d-0af6-14ac-16506c34f348" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="a814a289-0d8d-0af6-14ac-16506c34f348" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -884,7 +884,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6209c454-53f7-8a66-0639-73bbaaf14416" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="6209c454-53f7-8a66-0639-73bbaaf14416" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -897,9 +897,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="466318cd-1b4d-41ac-be05-ffe35e511c26" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="b5f0447a-c61d-c902-a24d-424ad25be42a" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup"/>
-            <entryLink id="cfcc91f5-b518-78e5-d939-f7225a8c60fc" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
+            <entryLink id="466318cd-1b4d-41ac-be05-ffe35e511c26" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="b5f0447a-c61d-c902-a24d-424ad25be42a" hidden="false" collective="false" import="true" targetId="0d5ab763-c126-029a-3da9-203abeafdb53" type="selectionEntryGroup" name="Special Skills (Skaven)"/>
+            <entryLink id="cfcc91f5-b518-78e5-d939-f7225a8c60fc" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -908,7 +908,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="25a220af-23dd-7636-85e9-6047b6ed4ae3" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="25a220af-23dd-7636-85e9-6047b6ed4ae3" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <modifiers>
             <modifier type="set" field="minSelections" value="0"/>
           </modifiers>
@@ -924,7 +924,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true" name="Stash"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a071d4b1-739e-bf89-f22e-1b6602cf2c55" name="Warband  Rating" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1021,8 +1021,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+        <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -1136,12 +1136,12 @@
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="bc56-6b1d-e1c3-5cab" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
-        <infoLink id="ab29-26af-158b-7e4b" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
-        <infoLink id="e8f6-5bdd-0e63-b853" hidden="false" targetId="a01e-d581-3551-8397" type="rule"/>
+        <infoLink id="bc56-6b1d-e1c3-5cab" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
+        <infoLink id="ab29-26af-158b-7e4b" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
+        <infoLink id="e8f6-5bdd-0e63-b853" hidden="false" targetId="a01e-d581-3551-8397" type="rule" name="Large Target"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="579963c2-b42f-2254-f6e0-c4746cd13fc4" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1150,7 +1150,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1163,7 +1163,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1183,7 +1183,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1203,7 +1203,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1320,7 +1320,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="38f17f5d-5cb6-91b3-1e1a-97d8f3eb211e" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1329,7 +1329,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="a2b9acfb-52e5-b210-b30d-86a01ba8d005" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1342,7 +1342,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1362,7 +1362,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6c891bb7-ea61-b861-205b-c6c2af3abbc5" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="6c891bb7-ea61-b861-205b-c6c2af3abbc5" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1382,7 +1382,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup" name="Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1391,8 +1391,8 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="faa8d372-77d4-33a4-1a08-49fe27633c52" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
-        <entryLink id="f57b6a1f-5d40-44cc-70b1-45f6d23525c3" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
+        <entryLink id="faa8d372-77d4-33a4-1a08-49fe27633c52" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience"/>
+        <entryLink id="f57b6a1f-5d40-44cc-70b1-45f6d23525c3" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20"/>
@@ -1401,7 +1401,7 @@
     </selectionEntry>
   </selectionEntries>
   <infoLinks>
-    <infoLink id="bc6ab1b0-ad56-fcef-5ed7-968f231af91b" hidden="false" targetId="bd2100cc-65f9-2311-e4b9-d0e6830884c3" type="rule"/>
+    <infoLink id="bc6ab1b0-ad56-fcef-5ed7-968f231af91b" hidden="false" targetId="bd2100cc-65f9-2311-e4b9-d0e6830884c3" type="rule" name="EXP Adancement"/>
   </infoLinks>
   <sharedSelectionEntries>
     <selectionEntry id="8acf5ee1-3430-be22-ec94-15b12e15e497" name="+1 A" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1713,7 +1713,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule"/>
+            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule" name="Avoid stun:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="10"/>
@@ -1744,7 +1744,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="5"/>
@@ -1761,7 +1761,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
+            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="80"/>
@@ -1810,15 +1810,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry"/>
-        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry"/>
-        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry"/>
-        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry"/>
-        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry"/>
-        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry"/>
-        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
-        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry"/>
-        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry"/>
+        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I"/>
+        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry" name="-1 S"/>
+        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS"/>
+        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS"/>
+        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T"/>
+        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry" name="-1 A"/>
+        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
+        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry" name="-1 LD"/>
+        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry" name="-1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="36e117d8-419f-59b9-e337-512db3c6c990" name="Characteristic Increases" hidden="false" collective="false" import="true">
@@ -1833,15 +1833,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry"/>
-        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry"/>
-        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry"/>
-        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry"/>
-        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry"/>
-        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry"/>
-        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
-        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry"/>
-        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry"/>
+        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry" name="+1 I"/>
+        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry" name="+1 S"/>
+        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry" name="+1 WS"/>
+        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry" name="+1 BS"/>
+        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry" name="+1 T"/>
+        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry" name="+1 A"/>
+        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry" name="+1 M"/>
+        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry" name="+1 LD"/>
+        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry" name="+1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bd8689c9-bc5c-df7b-87b9-aad34e27a295" name="Combat Skills" hidden="false" collective="false" import="true">
@@ -1943,24 +1943,6 @@ only applies when they are armed with normal swords or weeping blades, and not w
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="50dfad7a-35b1-bee6-657c-d603b181977d" name="Equipment" hidden="false" collective="false" import="true">
-      <constraints>
-        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
-        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
-        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
-      </entryLinks>
-    </selectionEntryGroup>
     <selectionEntryGroup id="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
@@ -1983,7 +1965,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="a022bf96-d456-1fd8-41e6-fd0882f5ed93" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1994,7 +1976,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2009,7 +1991,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2040,7 +2022,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2055,7 +2037,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2078,8 +2060,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule"/>
+            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule" name="Difficult To Use"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="37972d57-6f98-64fc-0e7c-cc3c30174a11" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2090,7 +2072,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2105,7 +2087,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2128,7 +2110,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="fcc1d76e-a482-00a0-03fb-fecd9deb538e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2139,7 +2121,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2154,7 +2136,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2177,8 +2159,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule"/>
-            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule" name="Strike Last"/>
+            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="eafc9bba-c5a2-09d3-627c-c5c102a70528" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2189,7 +2171,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2204,7 +2186,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2227,9 +2209,9 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule"/>
-            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule"/>
-            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule" name="Strike First"/>
+            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule" name="Unwieldy:"/>
+            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="3ef9bbbf-a875-133e-a275-fb47750ca7d8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2240,7 +2222,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2255,7 +2237,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2278,7 +2260,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="e1ae1bcf-84ef-dd9f-ae28-ed867c321df4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2289,7 +2271,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2304,7 +2286,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2330,7 +2312,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2347,7 +2329,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule"/>
+            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule" name="Concussion"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="0608e581-cb18-48b9-ab15-a1c7143f9203" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2358,7 +2340,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2373,7 +2355,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2396,7 +2378,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2413,8 +2395,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="aaef08ab-959e-c1cb-cce3-c9409cfc73c2" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2425,7 +2407,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2440,7 +2422,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2463,8 +2445,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule"/>
-            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule" name="Cavalry Weapon"/>
+            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="50469495-65e4-8313-fb4a-b47e3f3d4e5d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2475,7 +2457,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2490,7 +2472,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2557,10 +2539,10 @@ ignores the special rules for Animosity.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="1ceb77a9-9490-4927-18d2-176840913753" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
-            <infoLink id="75a41582-d588-841e-a159-6334eff22df8" hidden="false" targetId="f5ff4eee-7b45-2b25-aa0f-6761166c4b3d" type="rule"/>
-            <infoLink id="779a713a-057a-1f49-45ee-2ce15e630718" hidden="false" targetId="e8a37d75-61fb-abbf-07da-e4e376363521" type="rule"/>
-            <infoLink id="df893a03-c6c2-a930-e8be-4279765c6067" hidden="false" targetId="d8f7a6aa-6b24-e322-5ae7-ffc1ca009807" type="rule"/>
+            <infoLink id="1ceb77a9-9490-4927-18d2-176840913753" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
+            <infoLink id="75a41582-d588-841e-a159-6334eff22df8" hidden="false" targetId="f5ff4eee-7b45-2b25-aa0f-6761166c4b3d" type="rule" name="Pair"/>
+            <infoLink id="779a713a-057a-1f49-45ee-2ce15e630718" hidden="false" targetId="e8a37d75-61fb-abbf-07da-e4e376363521" type="rule" name="Climb"/>
+            <infoLink id="df893a03-c6c2-a930-e8be-4279765c6067" hidden="false" targetId="d8f7a6aa-6b24-e322-5ae7-ffc1ca009807" type="rule" name="Cumbersome"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="123f6ea4-2640-1624-80c1-2697680e7947" name="Gromril Weapon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2568,7 +2550,7 @@ ignores the special rules for Animosity.</description>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="d0d50b0f-e97a-1242-e69d-721081a26b9c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="d0d50b0f-e97a-1242-e69d-721081a26b9c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="105"/>
@@ -2580,7 +2562,7 @@ ignores the special rules for Animosity.</description>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="54948459-a4c0-a6e0-b6ff-87b2b75887ac" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="54948459-a4c0-a6e0-b6ff-87b2b75887ac" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="70"/>
@@ -2603,9 +2585,9 @@ ignores the special rules for Animosity.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="848f907d-4112-9dd6-6265-4b027cc68f2b" hidden="false" targetId="f5ff4eee-7b45-2b25-aa0f-6761166c4b3d" type="rule"/>
-            <infoLink id="ce7e4a89-88ab-8484-de1e-070b733f8a18" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
-            <infoLink id="f49bbf9e-77b1-d2ac-4c5d-c5839a426b32" hidden="false" targetId="379ad661-b836-65ae-9597-ad7a1a45f44d" type="rule"/>
+            <infoLink id="848f907d-4112-9dd6-6265-4b027cc68f2b" hidden="false" targetId="f5ff4eee-7b45-2b25-aa0f-6761166c4b3d" type="rule" name="Pair"/>
+            <infoLink id="ce7e4a89-88ab-8484-de1e-070b733f8a18" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
+            <infoLink id="f49bbf9e-77b1-d2ac-4c5d-c5839a426b32" hidden="false" targetId="379ad661-b836-65ae-9597-ad7a1a45f44d" type="rule" name="Venomous"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="dda08183-b8c4-a341-54c1-566ea6ee1884" name="Gromril Weapon" hidden="false" collective="false" import="true" type="upgrade">
@@ -2613,7 +2595,7 @@ ignores the special rules for Animosity.</description>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="fbc3cb97-fcdf-96e6-2111-a6be62725676" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="fbc3cb97-fcdf-96e6-2111-a6be62725676" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="150"/>
@@ -2625,7 +2607,7 @@ ignores the special rules for Animosity.</description>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a533b871-a1e9-4bfc-ede9-1df6a2d772c2" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="a533b871-a1e9-4bfc-ede9-1df6a2d772c2" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100"/>
@@ -2858,8 +2840,8 @@ a duelling pistol have a +1 bonus to hit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
-            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
+            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
+            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -2877,7 +2859,7 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2895,9 +2877,9 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
-            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule"/>
-            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
+            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
+            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule" name="Move Of Fire"/>
+            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -3002,9 +2984,9 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="1a781831-c054-d840-f30f-fc60d176bd67" hidden="false" targetId="82c14ad2-d59f-7967-5316-67eb2c4f9ce7" type="rule"/>
-            <infoLink id="def7ebda-fab2-a2dd-f585-2edbbe59b6c4" hidden="false" targetId="d6ce0b17-744e-af8c-009b-906a2b08634d" type="rule"/>
-            <infoLink id="0a994378-d05f-dbb9-ae41-2e7947443200" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="1a781831-c054-d840-f30f-fc60d176bd67" hidden="false" targetId="82c14ad2-d59f-7967-5316-67eb2c4f9ce7" type="rule" name="Stealthy"/>
+            <infoLink id="def7ebda-fab2-a2dd-f585-2edbbe59b6c4" hidden="false" targetId="d6ce0b17-744e-af8c-009b-906a2b08634d" type="rule" name="Poison"/>
+            <infoLink id="0a994378-d05f-dbb9-ae41-2e7947443200" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="25"/>
@@ -3022,7 +3004,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="60bf7f3d-1a31-d5ee-0429-cee2a7f550da" hidden="false" targetId="cbea94d4-c5a4-0b82-221b-78e7c3931890" type="rule"/>
+            <infoLink id="60bf7f3d-1a31-d5ee-0429-cee2a7f550da" hidden="false" targetId="cbea94d4-c5a4-0b82-221b-78e7c3931890" type="rule" name="-3 Save Modifier"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -3050,7 +3032,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -3074,7 +3056,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         </selectionEntry>
         <selectionEntry id="d7277e6e-49d8-50cb-988c-84bb7240da31" name="Maddness: Stupidity" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
+            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3083,7 +3065,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         </selectionEntry>
         <selectionEntry id="abc70d10-8ad7-23a1-6eb0-e05474350e3f" name="Madness: Frenzy" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule"/>
+            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule" name="Frenzy"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3097,7 +3079,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -3116,7 +3098,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry">
+            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -3145,7 +3127,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -3163,7 +3145,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -3203,7 +3185,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3362,11 +3344,11 @@ with a bow or crossbow (but not a crossbow pistol).</description>
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="e0a34910-f971-a9f6-2735-86e721bb904a" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
-        <entryLink id="fe0f976f-7e51-73d0-e9c4-ddb8c2facad4" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-        <entryLink id="5efa8246-ad2e-146b-67fe-b747a1c0cb22" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-        <entryLink id="41fcb00f-2237-9ca0-5b99-9f34f4e834e6" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-        <entryLink id="cb1b0dc4-3b79-b7d4-84c6-0353e001d60f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
+        <entryLink id="e0a34910-f971-a9f6-2735-86e721bb904a" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+        <entryLink id="fe0f976f-7e51-73d0-e9c4-ddb8c2facad4" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+        <entryLink id="5efa8246-ad2e-146b-67fe-b747a1c0cb22" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup" name="Shooting Skills"/>
+        <entryLink id="41fcb00f-2237-9ca0-5b99-9f34f4e834e6" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
+        <entryLink id="cb1b0dc4-3b79-b7d4-84c6-0353e001d60f" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="0d5ab763-c126-029a-3da9-203abeafdb53" name="Special Skills (Skaven)" hidden="false" collective="false" import="true">
@@ -3687,7 +3669,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3701,7 +3683,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3715,7 +3697,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3729,7 +3711,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3746,7 +3728,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3760,7 +3742,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3774,7 +3756,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="100"/>
@@ -3799,7 +3781,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3813,7 +3795,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="20"/>
@@ -3827,7 +3809,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3841,7 +3823,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3882,7 +3864,7 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3934,7 +3916,7 @@ Side effects: Mandrake Root is highly poisonous. At the end of the battle, roll 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="25"/>
@@ -3962,7 +3944,7 @@ on the Exploration chart as long as the Hero who possesses this map was not take
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -4010,7 +3992,7 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -4067,7 +4049,7 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -4095,7 +4077,7 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -4109,7 +4091,7 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -4233,4 +4215,7 @@ combat, roll a D6.
       <description>Rat Ogre is a large target for the purposes of targeting.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="4b38-46f2-e122-588f" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/The_Undead.cat
+++ b/The_Undead.cat
@@ -396,8 +396,8 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
+            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
+            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -755,8 +755,8 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" name="Speed Skills" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -982,10 +982,10 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup" name="Strength Skills"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup" name="Academic Skills"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>

--- a/The_Undead.cat
+++ b/The_Undead.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0b05773f-a863-7a25-f872-588b804e2c75" name="Undead (1a)" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0b05773f-a863-7a25-f872-588b804e2c75" name="Undead (1a)" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="888b0a33-7922-685c-49fc-591b3fb26358" name="Awakened Zombie" page="0" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -7,47 +7,47 @@
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7e03b263-c206-09f3-f9d3-47c0c9294235" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="888b0a33-7922-685c-49fc-591b3fb26358" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -67,26 +67,26 @@
       <infoLinks>
         <infoLink id="96c6-9499-ee14-7fae" name="Fear" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
         <infoLink id="96e9-14fe-b5f9-36a3" name="Immune To Psycology" hidden="false" targetId="da18bde4-5de9-f171-0b3c-d991b3deda82" type="rule"/>
-        <infoLink id="0388-65e0-98e0-f7ed" name="Imune to Posion" hidden="false" targetId="95da9bd6-05a4-a8c6-b97b-ef1fb856dd6d" type="rule"/>
+        <infoLink id="0388-65e0-98e0-f7ed" name="Imune to Poison" hidden="false" targetId="95da9bd6-05a4-a8c6-b97b-ef1fb856dd6d" type="rule"/>
         <infoLink id="7769-4b2c-893c-4ad6" name="May not run" hidden="false" targetId="0466-826b-c037-b4a0" type="rule"/>
         <infoLink id="4bb0-5f22-136e-03d7" name="No Brain" hidden="false" targetId="7eca-4a4f-438f-495b" type="rule"/>
         <infoLink id="d504-3648-14f6-7e34" name="No Pain" hidden="false" targetId="eadc3157-a303-2d60-42c7-80c2ad6974d9" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="888b0a33-7922-685c-49fc-591b3fb26358-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="888b0a33-7922-685c-49fc-591b3fb26358-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b8be0a78-d4e6-48da-e949-00e6b88b0b55" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4169d02d-8700-5b0c-f535-9c6a11a4ce2b" name="Equipment" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="4169d02d-8700-5b0c-f535-9c6a11a4ce2b" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -96,105 +96,105 @@
             <modifier type="set" field="name" value="Set Resurrected Hero Characteristics"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2436-990d-53ff-2a27" type="min"/>
+            <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2436-990d-53ff-2a27" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Dire Wolves" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="5" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="03db3be8-cefc-ad94-7afb-227b97cb7434" name="Dire Wolves" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -229,108 +229,108 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         <infoLink id="110f-5b80-5567-3e2f" name="No Pain" hidden="false" targetId="eadc3157-a303-2d60-42c7-80c2ad6974d9" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="50"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" name="Dregs" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="3" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="2bb25071-df94-bc53-5557-fd2deccf25d4" name="Dregs" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="93700e68-f80c-ad1c-b5cd-06fd3c7e7537" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -348,60 +348,60 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7daa68c-56da-e5c0-ff61-454d0e70fc3a" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="04fe2754-4270-2490-96f1-ab3b718bec62" name="Serious Injuries" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6874fd6e-a707-b236-686b-975e3425b3f2" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e486a1eb-1be8-c547-e111-cf507ef97a76" name="Skills" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
             <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -409,8 +409,8 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="20"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="889151de-4826-5f00-5dbb-fcf546ebedbb" name="Ghouls" page="0" hidden="false" collective="false" import="true" type="model">
@@ -419,92 +419,92 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -525,60 +525,60 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         <infoLink id="d9a3-9e25-a164-451e" name="Fear" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ffab3949-b7e7-0463-5c47-b05ae207fdbd" name=" Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="95dc4d07-7bf0-82ff-00a2-18a4c7c6aa7a" name="Characteristic Increases" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9a736f7c-0a1a-2561-68bc-36da58b28c84" name="Serious Injuries" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
+                <condition field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c015fc99-0af0-e3a8-7f2a-85178866327b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="c015fc99-0af0-e3a8-7f2a-85178866327b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="63218ed0-c131-966a-df37-be55d3e983cf" name="Skills" page="0" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
+                <condition field="selections" scope="889151de-4826-5f00-5dbb-fcf546ebedbb" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="7dbab9e0-3266-e802-a15e-9cd768e147de" name="Skills" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -587,105 +587,105 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         <entryLink id="2c761416-6f59-1a4f-2742-25e90f596c03" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="40.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="40"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Necromancer" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="78441028-11bf-6e67-5d4e-8ac796b2cea9" name="Necromancer" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83ab8692-01da-65c5-af52-a55d4800f012" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -703,213 +703,213 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4c359fa9-8570-3c9d-56b9-c03be92aa0f6" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a1391776-47ea-0568-037f-ec8f44d71045" name="Serious Injuries" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ab0d5c14-996b-9379-7070-817be5b9161a" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup">
+            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases">
               <modifiers>
-                <modifier type="increment" field="minSelections" value="0.0"/>
+                <modifier type="increment" field="minSelections" value="0"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9f7d41cd-13db-b929-0b5e-8b2cfbe8ca02" name="Skills" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
             <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f7f71508-28ee-8e1f-42ab-621f4f639311" name="Magic" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="87b05dcd-7c4f-4b48-215e-226c08d46e8d" hidden="false" collective="false" import="true" targetId="5b051df2-86a2-4480-25d1-a99dcbed79b0" type="selectionEntryGroup"/>
+            <entryLink id="87b05dcd-7c4f-4b48-215e-226c08d46e8d" hidden="false" collective="false" import="true" targetId="5b051df2-86a2-4480-25d1-a99dcbed79b0" type="selectionEntryGroup" name="Necromancy"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="a7d4eb84-400b-29e8-339c-fceebcba1553" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d4-ea22-1149-d2cb" type="min"/>
+            <constraint field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d4-ea22-1149-d2cb" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="35"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83ade99f-e9ef-d25a-59ac-ca3f3def011c" name="Stash" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38a7-02c0-1b8a-37b6" type="min"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38a7-02c0-1b8a-37b6" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true" name="Stash"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="74cb-4266-baac-3ca5" name="Wyrdstone" hidden="false" collective="false" import="true" type="upgrade">
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" name="Equipment" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83acbe09-ec66-c45c-0f5b-1a9e0017016e" name="Vampire" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <profiles>
         <profile id="9bad7e19-0288-3d5d-12cf-efdc8815570d" name="Vampire" page="0" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c87526-fae5-8945-97c3-057d97df69e7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="62be0dba-2c77-76b0-3da3-48c05611f170" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8acf5ee1-3430-be22-ec94-15b12e15e497" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0cbce569-483e-fc61-9a46-75bb7f52573a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="492ef626-87b8-7b39-378d-38fbd1ffb131" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abc4f440-9124-351f-831d-aaf5be4d3ae4" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf7c1f26-0442-54db-cacc-44dc499dcebc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bbd9ff4c-4aa7-432d-a143-b786400cef79" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c6e571-9da5-51a2-4053-aeca9035e1a2" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="043d62b3-76f8-822e-3d67-9c3806889918" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="83acbe09-ec66-c45c-0f5b-1a9e0017016e" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -931,78 +931,78 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
         <infoLink id="805469f7-bb7a-b8b7-af35-10f350d30d56" name="Fear" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
         <infoLink id="db655720-13b0-00a1-1ab2-c2c866ff30b5" name="Immune To Psycology" hidden="false" targetId="da18bde4-5de9-f171-0b3c-d991b3deda82" type="rule"/>
         <infoLink id="d9bea97d-375a-4777-1d8a-da61d1009c15" name="No Pain" hidden="false" targetId="eadc3157-a303-2d60-42c7-80c2ad6974d9" type="rule"/>
-        <infoLink id="fc6920ab-6f9d-082d-e53e-d39db9682250" name="Imune to Posion" hidden="false" targetId="95da9bd6-05a4-a8c6-b97b-ef1fb856dd6d" type="rule"/>
+        <infoLink id="fc6920ab-6f9d-082d-e53e-d39db9682250" name="Imune to Poison" hidden="false" targetId="95da9bd6-05a4-a8c6-b97b-ef1fb856dd6d" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a359fe11-ad97-3216-79e2-42fa0fcef557" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="56248f6d-5ee0-e166-254d-f40501f26f09" name="Serious Injuries" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a9874b15-5410-29f0-f05c-e629500fc5f5" name="Characteristic Increases" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5d5c6559-2773-1cc5-3835-0eb5869758f2" name="Skills" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup" name="Strength Skills"/>
             <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
             <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup" name="Academic Skills"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="9e2cb516-6834-4a3e-ec39-9855b3d6ed2d" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e674-1a3a-6be5-c1b0" type="min"/>
+            <constraint field="selections" scope="parent" value="20" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e674-1a3a-6be5-c1b0" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="110"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="16763088-15c1-4f72-fdfe-153003be4a24" name="Zombies" page="0" hidden="false" collective="false" import="true" type="model">
@@ -1024,17 +1024,17 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
       <infoLinks>
         <infoLink id="92c3-c86c-6c82-2736" name="Fear" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
         <infoLink id="f45c-503e-3840-73e7" name="Immune To Psycology" hidden="false" targetId="da18bde4-5de9-f171-0b3c-d991b3deda82" type="rule"/>
-        <infoLink id="3d95-66c3-f27b-fcba" name="Imune to Posion" hidden="false" targetId="95da9bd6-05a4-a8c6-b97b-ef1fb856dd6d" type="rule"/>
+        <infoLink id="3d95-66c3-f27b-fcba" name="Imune to Poison" hidden="false" targetId="95da9bd6-05a4-a8c6-b97b-ef1fb856dd6d" type="rule"/>
         <infoLink id="9c6e-89f7-8b62-eda0" name="May not run" hidden="false" targetId="0466-826b-c037-b4a0" type="rule"/>
         <infoLink id="6e8c-bb17-a6f4-3ffc" name="No Pain" hidden="false" targetId="eadc3157-a303-2d60-42c7-80c2ad6974d9" type="rule"/>
         <infoLink id="08e5-a011-d695-ab21" name="No Brain" hidden="false" targetId="7eca-4a4f-438f-495b" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="15.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
+        <cost name="pts" typeId="points" value="15"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -1044,165 +1044,165 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
   <sharedSelectionEntries>
     <selectionEntry id="8acf5ee1-3430-be22-ec94-15b12e15e497" name="+1 A" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e03b263-c206-09f3-f9d3-47c0c9294235" name="+1 BS" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0cbce569-483e-fc61-9a46-75bb7f52573a" name="+1 I" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6a2720c-06c4-d495-d8e5-0eeb2009570a" name="+1 LD" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="492ef626-87b8-7b39-378d-38fbd1ffb131" name="+1 M" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="62be0dba-2c77-76b0-3da3-48c05611f170" name="+1 S" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" name="+1 T" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a3c87526-fae5-8945-97c3-057d97df69e7" name="+1 W" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" name="+1 WS" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="06c6e571-9da5-51a2-4053-aeca9035e1a2" name="-1 A" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a93c5e1e-9169-8d09-5cba-5aa094184fe1" name="-1 BS" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" name="-1 I" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="043d62b3-76f8-822e-3d67-9c3806889918" name="-1 LD" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bf7c1f26-0442-54db-cacc-44dc499dcebc" name="-1 M" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" name="-1 S" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" name="-1 T" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bbd9ff4c-4aa7-432d-a143-b786400cef79" name="-1 W" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="abc4f440-9124-351f-831d-aaf5be4d3ae4" name="-1 WS" page="0" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f0fc009a-7990-32ef-b84b-b631058620e2" name="Experience" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="1.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="1"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b39ee84c-3f79-227e-4b39-8469fb19d56a" name="Gold" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
-        <cost name="pts" typeId="points" value="1.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="1"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0f2c78d6-e019-6b88-136a-9e00031645e5" name="Promoted" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" name="Academic Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="06d395bb-92a1-0ef9-339a-24781d43a616" name="Sorcery" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="ca2f0786-aaea-3f19-9f88-79fa24190fc3" name="Sorcery" page="0" hidden="false">
@@ -1210,13 +1210,13 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b70a36b7-25ec-9343-6e1e-b5896a0bce60" name="Battle Tongue" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="d5543d40-504a-8a9c-1834-9fb4480270ac" name="Battle Tongue" page="0" hidden="false">
@@ -1224,13 +1224,13 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7a4d4eec-5263-6896-1314-34c1a9265763" name="Streetwise" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="4bc58fa0-c8e1-8c7a-4608-d0d521dc245f" name="Streetwise" page="0" hidden="false">
@@ -1238,13 +1238,13 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a8550f60-6b54-e8b5-0404-edd81d0a94fd" name="Haggle" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="f24c33d6-eaba-c2f1-1489-17fcf5141a24" name="Haggle" page="0" hidden="false">
@@ -1252,13 +1252,13 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f90e4f05-f298-df4a-320a-e6354978048b" name="Arcane Lore" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="edcde1a4-663c-7c48-35e9-6c48b22fb8f4" name="Arcane Lore" page="0" hidden="false">
@@ -1266,13 +1266,13 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d45a55a3-6a34-e15e-4c2a-596621c66558" name="Wyrdstone Hunter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="467a2ef9-d383-5d6f-8359-58bde733f4e8" name="Wyrdstone Hunter" page="0" hidden="false">
@@ -1281,13 +1281,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="59ff18a1-758c-d172-a2ee-9831fe13e548" name="Warrior Wizard" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="1c9f51c4-f720-6acb-d802-769f62149251" name="Warrior Wizard" page="0" hidden="false">
@@ -1295,22 +1295,22 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" name="Armor" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="bd144faf-2ee7-d967-947b-e411ac750901" name="Light Armor" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1323,8 +1323,8 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="20"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dca0ad0f-ab8a-6fe8-18cc-6b207a23e8c5" name="Heavy Armor" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1337,8 +1337,8 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="50.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="50"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="57d232c8-f782-bb72-4d7c-222332e93e51" name="Helmet" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1351,11 +1351,11 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule"/>
+            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule" name="Avoid stun:"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8937e866-bd85-b101-3b07-7e552038c9a2" name="Shield" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1368,8 +1368,8 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6980f8c9-e102-2440-30da-a10572cde567" name="Buckler" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1382,11 +1382,11 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="179351b1-b943-159c-70c0-5328a17a363b" name="Barding" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1399,11 +1399,11 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
+            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="80.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="80"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97262f51-4a0b-7127-c03a-9499e7e38a0a" name="Gromril Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1411,13 +1411,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             <profile id="9198fa07-1c51-4b16-db0f-a40e4cdb47f2" name="Gromril Armour" page="0" hidden="false" typeId="94239014-ea28-23eb-4142-f492dc4caf17" typeName="Armor">
               <characteristics>
                 <characteristic name="Armor Save" typeId="26f1ea4e-6017-a8fa-db2b-5c2a83aea46b">4+</characteristic>
-                <characteristic name="Special" typeId="ff797ec4-8d7e-cab1-656e-896ae3ed005f">Not Showed By Shield </characteristic>
+                <characteristic name="Special" typeId="ff797ec4-8d7e-cab1-656e-896ae3ed005f">Not Showed By Shield</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="150.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="150"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c5858e9f-c606-bb70-93af-8a7d6cde63e7" name="Ithilmar Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1430,73 +1430,73 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="90.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="90"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="f42ac18f-5b17-105f-54fa-9b8a3c426954" name="Characteristic Decreases" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry"/>
-        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry"/>
-        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry"/>
-        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry"/>
-        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry"/>
-        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry"/>
-        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
-        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry"/>
-        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry"/>
+        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I"/>
+        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry" name="-1 S"/>
+        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS"/>
+        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS"/>
+        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T"/>
+        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry" name="-1 A"/>
+        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
+        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry" name="-1 LD"/>
+        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry" name="-1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="36e117d8-419f-59b9-e337-512db3c6c990" name="Characteristic Increases" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry"/>
-        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry"/>
-        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry"/>
-        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry"/>
-        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry"/>
-        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry"/>
-        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
-        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry"/>
-        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry"/>
+        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry" name="+1 I"/>
+        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry" name="+1 S"/>
+        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry" name="+1 WS"/>
+        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry" name="+1 BS"/>
+        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry" name="+1 T"/>
+        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry" name="+1 A"/>
+        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry" name="+1 M"/>
+        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry" name="+1 LD"/>
+        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry" name="+1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bd8689c9-bc5c-df7b-87b9-aad34e27a295" name="Combat Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="ce9199d6-76a7-4a61-a2f7-1c455f85f7ff" name="Step Aside" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="5eec59a7-d70a-6aca-53f1-0bb0aa6f2f28" name="Step Aside" page="0" hidden="false">
@@ -1504,13 +1504,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="eca4795b-79e1-a9cf-8b0c-c45720e58eba" name="Strike To Inure" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="b0873110-394b-caf5-ff51-10d504987872" name="Strike To injure" page="0" hidden="false">
@@ -1518,13 +1518,13 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="711fe0b5-ee48-771c-9fb3-4334ea4ea04b" name="Expert Swordsman" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="febd00dc-6add-2876-cd50-adfe163fc4b6" name="Expert Swordsman" page="0" hidden="false">
@@ -1533,13 +1533,13 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d874e48b-2d36-f775-deb3-0e4db17c67c9" name="Web Of Steel" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="7a1dcc12-4bc8-c8be-6c15-66e1584f0973" name="Web Of Steel" page="0" hidden="false">
@@ -1547,13 +1547,13 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d35ac8d5-1a70-5c1c-e4a1-cc2d819e62aa" name="Weapons Traning" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="6799f229-089c-bc70-ecb5-a16d3f4a21a3" name="Weapons Traning" page="0" hidden="false">
@@ -1561,13 +1561,13 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97106b1b-3866-90a6-0521-c6b6d794a6fe" name="Combat Master" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="90c9b94a-4eb7-cda4-fb71-3808b78043fd" name="Combat Master" page="0" hidden="false">
@@ -1575,40 +1575,40 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="50dfad7a-35b1-bee6-657c-d603b181977d" name="Equipment" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
-        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
-        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
+        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
+        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup" name="Missile Weapons"/>
+        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup" name="War Gear"/>
+        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="0c67e100-6cf2-2342-3af1-6445f5a163c9" name="Dagger" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1621,43 +1621,43 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="a022bf96-d456-1fd8-41e6-fd0882f5ed93" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="6.0"/>
+                <modifier type="set" field="points" value="6"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db350a56-7488-0569-a892-70cea870a2a4" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="4.0"/>
+                <modifier type="set" field="points" value="4"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="2"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="467a0329-1c84-acb1-b68f-495561849ac2" name="Axe" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1672,38 +1672,38 @@ only applies when they are armed with normal swords or weeping blades, and not w
           <selectionEntries>
             <selectionEntry id="5f8a42fc-4bd6-10d7-cd86-1a436766e50e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="15.0"/>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5694af16-4f26-7ece-b0af-6d8ec0b0548d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="10.0"/>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1efe5bb0-e06e-526f-e580-983a8da4b54e" name="Morning Star" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1716,44 +1716,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule"/>
+            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule" name="Difficult To Use"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="37972d57-6f98-64fc-0e7c-cc3c30174a11" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="45.0"/>
+                <modifier type="set" field="points" value="45"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fa8afbe-87f0-7dfe-566f-bf7c03e5a08c" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6b5ce748-913b-065d-6a34-5639d9a94b3d" name="Sword" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1766,43 +1766,43 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="fcc1d76e-a482-00a0-03fb-fecd9deb538e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e954ffd3-9cf2-a93b-6362-2c1c76a6c6b9" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fe26dc5f-994d-51e3-f2da-34fbf40ffb8a" name="Double Handed Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1815,44 +1815,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule"/>
-            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule" name="Strike Last"/>
+            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="eafc9bba-c5a2-09d3-627c-c5c102a70528" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="45.0"/>
+                <modifier type="set" field="points" value="45"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c55ad349-89d8-aabe-619d-d334481460c0" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c9494475-3720-3676-42b0-8a7c261ae004" name="Spear" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1865,45 +1865,45 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule"/>
-            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule"/>
-            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule" name="Strike First"/>
+            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule" name="Unwieldy:"/>
+            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="3ef9bbbf-a875-133e-a275-fb47750ca7d8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f737ba7-658d-f833-131c-48735ada0760" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5f0e7a6b-e633-9b8e-d06a-fb5c82e885b9" name="Halberd" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1916,48 +1916,48 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="e1ae1bcf-84ef-dd9f-ae28-ed867c321df4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e625c4af-e133-1445-41fe-f9b23e142828" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8eed780c-18dd-ae9e-70a2-047fdd644c7b" name="Free Dagger" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <profiles>
             <profile id="c419d855-1a49-a967-4b92-d910d59fd87b" name="Free Dagger" page="0" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
@@ -1968,11 +1968,11 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e58cd147-18f5-e468-6077-679bc48de6c6" name="Club,Mace, Hammer" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1985,43 +1985,43 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule"/>
+            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule" name="ConCussion"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="0608e581-cb18-48b9-ab15-a1c7143f9203" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="9.0"/>
+                <modifier type="set" field="points" value="9"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="14736779-2638-2e8d-aa0e-d8eba9ac62da" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="6.0"/>
+                <modifier type="set" field="points" value="6"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="3.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="3"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dfbc868a-c6a4-80ae-2c3a-1789b3dde6dd" name="Fist" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2034,11 +2034,11 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="46a156bc-9d62-8bf1-94aa-26ed5a1cad42" name="Flail" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2051,44 +2051,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="aaef08ab-959e-c1cb-cce3-c9409cfc73c2" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="45.0"/>
+                <modifier type="set" field="points" value="45"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="287e8d26-b5e0-f724-72af-a96a7d60dd9f" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="30.0"/>
+                <modifier type="set" field="points" value="30"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7b8b4f8a-d2bc-1564-a447-a5bd22994f8a" name="Lance" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2101,44 +2101,44 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule"/>
-            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule" name="Cavalry Weapon"/>
+            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="50469495-65e4-8313-fb4a-b47e3f3d4e5d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="120.0"/>
+                <modifier type="set" field="points" value="120"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9672b2b9-bd40-6d29-3481-03cc43fc620d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="set" field="points" value="80.0"/>
+                <modifier type="set" field="points" value="80"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="40"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d5b77a74-af16-76e5-a643-97b6d31673c5" name="Ball and Chain" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2152,9 +2152,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
           </profiles>
           <rules>
             <rule id="864c3646-5890-c82c-6ee7-bbffb4450668" name="Incredible Force" page="0" hidden="false">
-              <description>No armour saves are allowed against wounds caused by a Ball and Chain and any hit that successfully wounds will do 1D3 wounds instead of 1
-
-</description>
+              <description>No armour saves are allowed against wounds caused by a Ball and Chain and any hit that successfully wounds will do 1D3 wounds instead of 1</description>
             </rule>
             <rule id="9e707917-73d2-ca7b-e3ec-590a01e1a38b" name="Random:" page="0" hidden="false">
               <description>The first turn he starts swinging the Ball and Chain, the model is moved 2D6&quot; in a direction nominated by the controlling player. In his subsequent Movement phases, roll a D6 to determine
@@ -2170,9 +2168,7 @@ Opponents wishing to attack a Ball and Chain wielding model suffer a To Hit pena
 
 The Ball and Chain wielder cannot be held in close combat and will automatically move even if h e starts the Movement phase in base contact with another model. If the model moves into contact with a building, wall, or other obstruction, he is automatically taken out of action.
 
-ignores the special rules for Animosity.
-
-</description>
+ignores the special rules for Animosity.</description>
             </rule>
             <rule id="a2948139-cad2-7570-b3cf-8f995b16961d" name="CumbersomE" page="0" hidden="false">
               <description>a model equipped with one may carry no other weapons or equipment, only Mad Cap Mushrooms which they must have.</description>
@@ -2182,22 +2178,22 @@ ignores the special rules for Animosity.
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="38175608-757c-9eb5-59a8-2f7b6b1019e2" name="Missile Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="1d6b2c12-9dac-3bd9-d347-474ae54769a9" name="Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2211,8 +2207,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="be4e70ce-f2a1-8dfa-9035-058eb1c95243" name="Cross Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2226,8 +2222,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="25"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f2c1760d-e4f4-8d3a-fcda-84379e0b3aca" name="Short Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2241,8 +2237,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e7ec5cd8-4ff0-f9b7-60a4-11d73a62708f" name="Blunderbuss" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2256,8 +2252,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="11a5f8ff-a6da-82cd-a638-423e3892d66f" name="Crossbow Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2271,8 +2267,8 @@ ignores the special rules for Animosity.
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="35"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="21769e56-0db7-859a-95df-be7e48c3ab13" name="Dueling Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2296,12 +2292,12 @@ a duelling pistol have a +1 bonus to hit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
-            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
+            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
+            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0d41d311-b3bc-ac40-3094-2aadf128c780" name="Elf Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2315,11 +2311,11 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="35"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8f320f8f-a366-6288-2f18-f74708b6a407" name="Hand Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2333,13 +2329,13 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
-            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule"/>
-            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
+            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
+            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule" name="Move Of Fire"/>
+            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="35.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="35"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="51e5c18d-d32f-15f8-e231-cd527cbc9194" name="Long Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2353,14 +2349,14 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ecb7edf4-93de-d2c6-0853-c960bcf065c8" name="Hunting Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <costs>
-            <cost name="pts" typeId="points" value="200.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="200"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a3d6e341-41b1-b147-933d-a7f25b6219a7" name="Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2380,8 +2376,8 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="09822e77-d1ec-85ad-3d31-643311e268a9" name="Repeater Crossbow" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2395,8 +2391,8 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="40"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="70472c5d-bf97-753a-2b8c-3f1a54c6abff" name="Sling" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2410,8 +2406,8 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="2"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2582db34-2deb-3752-0e9a-8a309edbcfaa" name="Throwing Knives/stars" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2425,22 +2421,22 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="5b051df2-86a2-4480-25d1-a99dcbed79b0" name="Necromancy" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="0c3ddff7-96d2-9cfb-74c5-b7171d3e7088" name="1 Life Stealer" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2456,8 +2452,8 @@ Can not be cast on undead or  possessed.</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d1f76c6a-5d40-475e-b3d7-c1f561cadb2b" name="2 Re-animatiom" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2471,8 +2467,8 @@ Place the model within 6&quot; of the necromancer. It can not be placed in direc
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f92e62c0-8650-3149-1d9c-cb6745a3af63" name="3 Death Vision" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2485,8 +2481,8 @@ Place the model within 6&quot; of the necromancer. It can not be placed in direc
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7cd61a42-3f3a-76c4-976c-213a477b3dc9" name="4 Spell of Doom" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2501,8 +2497,8 @@ If they fail they get an imediate check on the injury table.</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2431affd-9208-e7c0-f831-f188f49fc5e9" name="5 Call of Vanhel" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2516,8 +2512,8 @@ If they move into base to base contact with an enemy, it counts as having charge
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="490cd705-4fd2-9c5b-56aa-e2fadb325281" name="6 Spell Of Awakening" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2533,22 +2529,22 @@ He is a normal zombie in all other respects.</characteristic>
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="2ace8f8f-6f26-2b7f-5407-332ed11d0355" name="Serious Injuries" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="78aa00f9-ee2f-2482-1090-4d1ca59a8169" name="Leg Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2558,15 +2554,15 @@ He is a normal zombie in all other respects.</characteristic>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="235f320e-f3a2-d485-4769-0b8a2a88fcf7" name="Severe Arm Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2576,26 +2572,26 @@ He is a normal zombie in all other respects.</characteristic>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d7277e6e-49d8-50cb-988c-84bb7240da31" name="Maddness: Stupidity" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
+            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="abc70d10-8ad7-23a1-6eb0-e05474350e3f" name="Madness: Frenzy" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule"/>
+            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule" name="Frenzy"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8902fa66-7b19-ed57-c029-35c34cd7efe2" name="Chest Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2605,15 +2601,15 @@ He is a normal zombie in all other respects.</characteristic>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dbccc133-7061-c16e-eb8b-ab7a378c418c" name="Blind In one Eye" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2624,15 +2620,15 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry">
+            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="213d3373-4b14-d558-fe3d-370cd420bb47" name="Old Battle Wound" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2642,8 +2638,8 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="569e02f1-7179-556f-8824-1219b3c42902" name="Nervous Condition" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2653,15 +2649,15 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fe54554d-0e2c-9a33-6a50-a38ce16ea71c" name="Hand Injury" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2671,15 +2667,15 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
-                <modifier type="set" field="minSelections" value="1.0"/>
+                <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="862a6b8f-fd65-9fec-da82-a1791ff77f8f" name="Bitter Emity" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2689,8 +2685,8 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4dab123f-803f-dc5f-ea99-5ea87ae20681" name="Hardened" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2700,8 +2696,8 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cf7e9bf2-6643-1719-c87b-61b79f7ae434" name="Horrible Scars" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2711,11 +2707,11 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="732f7f66-fdb2-5421-a06e-a18e90e6d9b8" name="Smashed Leg" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2725,27 +2721,27 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="52007ee0-cc99-b312-3650-cfab391e476c" name="Shooting Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="6e412341-cfdd-1cd2-9617-89e1db80a649" name="Trick Shooter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="75f5f275-f326-d555-5d4d-9603b968e777" name="Trick Shooter" page="0" hidden="false">
@@ -2753,13 +2749,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2f78e9cf-083b-de60-5dc6-aa4693f93662" name="Nimble" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="888f9ab7-efac-8b9a-4b64-350d27d109be" name="Nimble" page="0" hidden="false">
@@ -2767,13 +2763,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b4628d7b-54f0-007e-d857-88008b63adb7" name="Weapons Expert" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="72827526-238a-8f4c-1a63-f41c6660cf21" name="Weapons Expert" page="0" hidden="false">
@@ -2781,13 +2777,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="feecb448-3528-78fa-b91a-56c7821587ad" name="Eagle Eyes" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="2b06b2d4-b8c7-8e2b-6528-97de32d06b19" name="Eagle Eyes" page="0" hidden="false">
@@ -2795,13 +2791,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1fa884e8-d2d8-3118-188b-98cb1a3d1565" name="Pistolier" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="481962a4-f659-388b-9fde-1496c2ceba00" name="Pistolier" page="0" hidden="false">
@@ -2809,13 +2805,13 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e61270fc-7700-33cc-ec95-f0f5941833fd" name="Quick Shot" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="cec15b88-d45b-8f95-b041-8061a0391747" name="Quick Shot" page="0" hidden="false">
@@ -2824,13 +2820,13 @@ with a bow or crossbow (but not a crossbow pistol).</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5ab33d02-0d99-fc8b-5058-3f6c957d5744" name="Hunter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="f7e02dac-a51f-7e27-82ad-22132555bef5" name="Hunter" page="0" hidden="false">
@@ -2838,13 +2834,13 @@ with a bow or crossbow (but not a crossbow pistol).</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ece8f370-6d96-5508-c75e-e469e3290a13" name="Knife Fighter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="aaa7e060-2bb3-354c-31a6-332a8b5fe961" name="Knife Fighter" page="0" hidden="false">
@@ -2852,101 +2848,101 @@ with a bow or crossbow (but not a crossbow pistol).</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="39deaab7-93cc-922b-d866-f7368e56495a" name="Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="76cb-ff11-2c8d-6a63" name="Academic Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ccf-db47-a5f8-f775" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ccf-db47-a5f8-f775" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="9d37-173a-b5b3-c822" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cac0-aace-3c14-c62a" name="Combat Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d91-024d-c894-6f22" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d91-024d-c894-6f22" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="e365-d8ca-45b5-a8a2" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2875-b6c7-e956-38b8" name="Shooting Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59ca-eec7-be39-af06" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59ca-eec7-be39-af06" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="4cc9-9443-19fc-f9e2" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d666-feb7-40dd-763c" name="Speed Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51b-f1b2-188b-be33" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51b-f1b2-188b-be33" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="a139-aa85-a54e-05ed" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97f0-beff-79de-f996" name="Strength Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="313e-b076-dfbd-3e79" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="313e-b076-dfbd-3e79" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="a74a-898d-7ce5-6c07" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="2a62fe9a-16ae-b087-f5a5-47f19da37c89" name="Speed Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="3bb65cd7-5c4f-3f18-0a1c-85922b7bdef4" name="Scale Sheer Surfaces" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="4319dae5-face-906e-debf-19997db0f5b7" name="Scale Sheer Surfaces" page="0" hidden="false">
@@ -2955,13 +2951,13 @@ Movement, and does not need to make Initiative tests when doing so</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aa16dd2b-9873-72e9-fb25-8a9a697cc0ce" name="Dodge." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="559cda8e-dd5a-62c3-3c11-99e5a3c30d92" name="Dodge." page="0" hidden="false">
@@ -2969,13 +2965,13 @@ Movement, and does not need to make Initiative tests when doing so</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d88227c5-0c1b-7885-1435-67180bef016b" name="Jump Up" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="0f0ad3a6-9367-7873-55f8-c4ad0fdbe589" name="Jump Up" page="0" hidden="false">
@@ -2984,13 +2980,13 @@ wearing a helmet or because he has the No Pain special rule.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a35f147f-18b0-8304-0632-3d90a8aeb38b" name="Lightning Reflexes" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="fb1ac65f-7bc6-e64f-b7f3-4bae70bee33b" name="Lightning Reflexes" page="0" hidden="false">
@@ -2999,13 +2995,13 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0dc47a72-5378-9081-f141-3f8b5274f93a" name="Acrobat." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="a457974b-633e-a34c-18dc-58cf502f56b3" name="Acrobat" page="0" hidden="false">
@@ -3013,13 +3009,13 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="81c10a39-89d1-a85b-6d03-8fdde521ca0f" name="Leap" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="f464099c-a8d5-e6c3-832e-90607f3760a6" name="Leap" page="0" hidden="false">
@@ -3027,13 +3023,13 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5a8c0670-333b-f6e4-63aa-95f3809481e8" name="Sprint." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="cebba0f2-2f4b-5f1c-3101-08f082e40338" name="Sprint" page="0" hidden="false">
@@ -3041,27 +3037,27 @@ charging), the order of attack between the charger(s) and the warrior with this 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="9e76820a-3a93-f94a-a7c7-d31889583e06" name="Strength Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="5925429b-e4f5-6ffb-e14a-15bed5241afc" name="Mighty Blow" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="d940b4ab-2ac6-b296-48af-dbadc6b8689e" name="Mighty Blow" page="0" hidden="false">
@@ -3070,13 +3066,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6c5bd831-8cd8-838f-8d35-0c829ee6397e" name="Pit Fighter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="97f6f469-30e7-bd9f-0281-d44b19568bbb" name="Pit Fighter" page="0" hidden="false">
@@ -3084,13 +3080,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="499e0aa5-1296-7a29-5ae5-a1d38c7c654e" name="Resilient" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="78cdf4f5-0561-39da-c3f3-82000a40a2b3" name="Resilient" page="0" hidden="false">
@@ -3098,13 +3094,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1d15d220-4d5d-c25e-f9cc-6c82d54aaf24" name="Fearsome" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="bad193e4-5b8d-9b6b-6b5c-f9f3082572c9" name="Fearsome" page="0" hidden="false">
@@ -3112,13 +3108,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="82d80676-7114-6b28-82b1-5851133d1dca" name="Strongman" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="4300f1bc-89a1-6955-5b97-f8a81f0b5b27" name="Strongman" page="0" hidden="false">
@@ -3126,13 +3122,13 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e5248876-9211-cad5-5cc5-de5860de56c4" name="Unstoppable Charge" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <rules>
             <rule id="40b60f97-ac19-e6e0-70e6-4d655694d095" name="Unstoppable Charge" page="0" hidden="false">
@@ -3140,22 +3136,22 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="cd413ae9-4927-5bae-ff6e-93723ba44113" name="War Gear" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="79c9c680-da5e-78c9-9e6b-1360200cd213" name="Black Lotus" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3165,11 +3161,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6d926a98-4656-9782-cf2c-c6d7c8cfce52" name="Blessed Water" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3179,11 +3175,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4fc7ded6-c534-1735-fc46-0a68de7f5874" name="Bugman&apos;s Ale" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3193,11 +3189,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b666f570-da7b-8f8f-f63f-30dfcce33708" name="Cathayan Silk Clothes" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3207,11 +3203,11 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9598e4dd-04e8-d1f8-c25d-9e286ec1f3ed" name="Crimson Shade" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3224,11 +3220,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bcbc3583-cebe-ae6c-1613-0530f1f83d5d" name="Dark Venom" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3238,11 +3234,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1cafb109-3ed9-1b35-8c05-05a37ca5270e" name="Elven Cloak" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3252,11 +3248,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="100.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="100"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a2c3293d-3403-3549-2eea-c0b1be66566a" name="Garlic" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3266,8 +3262,8 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="1.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="1"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6665a576-6dbb-daa9-61a5-277abb2db97c" name="Halfling Cook Book" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3277,11 +3273,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="90e94c9a-b505-0d4a-e34b-3284ba64ffbe" name="Healing Herbs" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3291,11 +3287,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="20.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="20"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="608c9528-a785-cc65-f601-e31db8e08f00" name="(un)Holy Relic" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3305,11 +3301,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="76574461-1664-c71d-acbd-e0a471d2d2bb" name="Holy Tome" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3319,11 +3315,11 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="42ea245f-22f1-7cf0-ac6e-480d76e6d90e" name="Horse" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3349,8 +3345,8 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="40"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cd2b60e4-33cf-3441-ac05-b26aff4cc568" name="Hunting Arrows" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3360,11 +3356,11 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ff424c20-67c1-a8be-4db3-6fce5c831c33" name="Lantern" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3374,8 +3370,8 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="68ca3356-bc30-b017-dd79-86d700958a24" name="Lucky Charm" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3385,8 +3381,8 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="10"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="23b12fc8-765a-f41b-12d8-94746abb37f3" name="Mad Cap Mushrooms (Orcs)" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3399,8 +3395,8 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="25"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="444ae29c-bd6b-e577-1aa2-05375176ede4" name="Mandrake Root" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3412,11 +3408,11 @@ Side effects: Mandrake Root is highly poisonous. At the end of the battle, roll 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="25.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="25"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b8fcbd86-29d9-ffb3-bb41-1ca6d75d9c17" name="Mordhiem Map" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3440,11 +3436,11 @@ on the Exploration chart as long as the Hero who possesses this map was not take
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7c7981cc-3051-0886-b1ad-69f7e7057323" name="Net" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3455,8 +3451,8 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1053cb3f-c81c-325f-71c3-9cd65320a3f2" name="Rope And Hook" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3466,19 +3462,19 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="5"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="50fdf0ff-9749-00e2-6814-f22ca69ba575" name="Superior Black Powder" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
             <rule id="c19c8a90-8410-47be-49c1-1a4295ce3ae8" name="Superior Black Powder" page="0" hidden="false">
-              <description> +1 Strength to all blackpowder weapons that the model has. There is enough superior blackpowder to last for one game.</description>
+              <description>+1 Strength to all blackpowder weapons that the model has. There is enough superior blackpowder to last for one game.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="30"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ea883376-5b97-5986-5ca6-c9d12fc0b66c" name="Tome Of Magic" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3488,11 +3484,11 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bfa7d5e5-4f28-52d9-eea1-cf2855b1f039" name="Warhorse" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3518,8 +3514,8 @@ You may mount one of your Heroes on a warhorse in the coming battles. Warhorses 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="80.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="80"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="0eccb01c-3cd1-b1c6-edef-de00b04e67df" name="Wardog" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3545,11 +3541,11 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fb90c61e-63c8-ee98-05b2-afb1f4aae1d8" name="Squigg Prodder" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3559,8 +3555,8 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="15.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="15"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4bd08e4d-f4aa-d1ca-5f07-a33d57dd2c29" name="Mad Cap Mushrooms" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3573,11 +3569,11 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d4e0b60e-c797-a04d-6f7a-20c38cc6c1ce" name="Tears of Shallaya" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3587,11 +3583,11 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3615,7 +3611,7 @@ result as knocked down instead. This save is not modified by the opponent’s St
       <description>Hammers and other bludgeoning weapons are excellent to use for striking your enemy senseless. When using a hammer, club or mace, a roll of 2-4 is treated as stunned when rolling to see the extent of a model’s injuries.</description>
     </rule>
     <rule id="6118263e-03c4-68f7-694d-6ceebac4e80b" name="Cutting edge" page="0" hidden="false">
-      <description> A Cutting edgee has an extra save modifier of -1, so a model with Strength 4 using an Cutting edge has a -2 save modifier when he hits an opponent in hand-to-hand combat.</description>
+      <description>A Cutting edgee has an extra save modifier of -1, so a model with Strength 4 using an Cutting edge has a -2 save modifier when he hits an opponent in hand-to-hand combat.</description>
     </rule>
     <rule id="140e74d1-bf16-356b-c7d1-08b3bb5052b5" name="Difficult To Use" page="0" hidden="false">
       <description>A model with aDifficult To Use  may not use a second weapon or buckler in his other hand because it requires all his skill to wield it. He may carry a shield as normal though.</description>
@@ -3636,7 +3632,7 @@ Attacks have 4, etc. If a warrior is carrying a weapon in each hand, he receives
 no longer frenzied. He continues to fight as normal for the rest of the battle.</description>
     </rule>
     <rule id="6549136a-9a00-4d3a-b8fa-ecadf63e4744" name="Gromril weapon" page="0" hidden="false">
-      <description>A gromril weapon has an extra -1 save modifier, and costs four times the price of a normal weapon of its kind. </description>
+      <description>A gromril weapon has an extra -1 save modifier, and costs four times the price of a normal weapon of its kind.</description>
     </rule>
     <rule id="a3327e94-8ff2-b189-9303-34c54c57373f" name="Gun Save modifier" page="0" hidden="false">
       <description>even better at penetrating armour than their Strength  suggests. A warrior wounded by afirearm lmust make his armour save with a -2 modifier.</description>
@@ -3693,7 +3689,7 @@ combat, roll a D6.
       <description>model armed with a 2handed weapon may not use a shield, buckler or additional weapon in close combat. If the model has a shield he still gets a +1 bonus to his armour save against shooting.</description>
     </rule>
     <rule id="be37b096-f38b-d3f0-0c72-f18572a56f1d" name="Unwieldy:" page="0" hidden="false">
-      <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon. </description>
+      <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
     <rule id="0466-826b-c037-b4a0" name="May not run" hidden="false">
       <description>Zombies are slow Undead creatures and may not run (but may charge normally).</description>
@@ -3703,4 +3699,7 @@ combat, roll a D6.
 What did you expect?</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="a535-59b8-0d08-f13d" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/Witch_Hunters.cat
+++ b/Witch_Hunters.cat
@@ -183,7 +183,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" name="Skills" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="08cc3960-62eb-bff3-603d-9ae0ae57056b" name="Skills" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -417,9 +417,9 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
+            <entryLink id="b72d2347-64d2-8e68-c463-0e82a6723ff5" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
+            <entryLink id="6943bf03-8cfb-db4c-bd0a-f04356ec15ec" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
+            <entryLink id="bb755636-0b5c-95f0-6f44-ccb4319cb7f2" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -624,10 +624,10 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
-            <entryLink id="bc17-38e9-4027-5cb8" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
+            <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup" name="Speed Skills"/>
+            <entryLink id="bc17-38e9-4027-5cb8" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -817,11 +817,11 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
-            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" name="Strength Skills" hidden="false" collective="false" import="true" targetId="9e76820a-3a93-f94a-a7c7-d31889583e06" type="selectionEntryGroup"/>
-            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
-            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
+            <entryLink id="bc04a2e1-90c1-425b-78fa-a13e49cfb179" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup"/>
+            <entryLink id="c171b0c2-f16f-eb30-9160-efc35795a11b" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
+            <entryLink id="1a55ca39-174e-b3bd-5c43-b37a709bd42f" name="Speed Skills" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup"/>
+            <entryLink id="7dfe147c-aba4-13bc-bf11-383a8c4f97f3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
+            <entryLink id="1cd8773e-95ba-8894-60bc-b9371a36d1b4" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1012,7 +1012,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" name="Skills" hidden="false" collective="false" import="true" targetId="39deaab7-93cc-922b-d866-f7368e56495a" type="selectionEntryGroup"/>
+            <entryLink id="1db86a95-b3e2-8bef-db44-a3ad9861e582" name="Skills" hidden="false" collective="false" import="true" targetId="70b9-9a07-4088-7598" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>

--- a/Witch_Hunters.cat
+++ b/Witch_Hunters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="65788600-7fa0-eb7c-b1a3-36d0c3c506c6" name="Witch Hunters (1a)" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="65788600-7fa0-eb7c-b1a3-36d0c3c506c6" name="Witch Hunters (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Flagellants" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -118,7 +118,7 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="38f17f5d-5cb6-91b3-1e1a-97d8f3eb211e" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -127,9 +127,10 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7de5f8f9-b8fb-02db-1b9d-37658dd743e8" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-            <entryLink id="ffd3fea9-533a-d8fb-861e-c66a61197d55" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
-            <entryLink id="0b286487-3d73-3d5e-0541-d2aa37df2c11" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
+            <entryLink id="7de5f8f9-b8fb-02db-1b9d-37658dd743e8" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
+            <entryLink id="ffd3fea9-533a-d8fb-861e-c66a61197d55" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
+            <entryLink id="0b286487-3d73-3d5e-0541-d2aa37df2c11" hidden="false" collective="false" import="true" targetId="a2cf-6f28-f7c2-275d" type="selectionEntryGroup" name="Miscellaneous Equipment"/>
+            <entryLink import="true" name="Miscellaneous Equipment (1a)" hidden="false" id="6103-d482-7c1f-af96" type="selectionEntryGroup" targetId="27a7-c1bf-0c40-ff21"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -142,7 +143,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="f7f4f8bf-03e2-f72b-50df-d5db42554776" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -162,7 +163,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6c891bb7-ea61-b861-205b-c6c2af3abbc5" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="6c891bb7-ea61-b861-205b-c6c2af3abbc5" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -192,7 +193,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="faa8d372-77d4-33a4-1a08-49fe27633c52" name="Experience" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry"/>
-        <entryLink id="f57b6a1f-5d40-44cc-70b1-45f6d23525c3" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry"/>
+        <entryLink id="f57b6a1f-5d40-44cc-70b1-45f6d23525c3" hidden="false" collective="false" import="true" targetId="0f2c78d6-e019-6b88-136a-9e00031645e5" type="selectionEntry" name="Promoted"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40"/>
@@ -205,7 +206,7 @@
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32e9-0457-f9f7-0ba4" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="83ade99f-e9ef-d25a-59ac-ca3f3def011c-a31acb39-8ce9-d6d7-bcc9-f3144d63db48" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true" name="Stash"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d56d-57ab-3b6d-8dd0" name="Wyrdstone" hidden="false" collective="false" import="true" type="upgrade">
@@ -217,7 +218,7 @@
       </selectionEntries>
       <entryLinks>
         <entryLink id="dad9014c-4be3-4cca-3345-5808f02cbcce" name="Gold" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
-        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+        <entryLink id="6f878f2b-fa2b-6e2c-5bfe-a94012499470" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
@@ -249,7 +250,7 @@
         </rule>
       </rules>
       <categoryLinks>
-        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="889151de-4826-5f00-5dbb-fcf546ebedbb-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15"/>
@@ -368,7 +369,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="93700e68-f80c-ad1c-b5cd-06fd3c7e7537-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e7daa68c-56da-e5c0-ff61-454d0e70fc3a" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -377,7 +378,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="94ed96f9-bb95-c6f3-7c64-ada053e4eb0f" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -390,7 +391,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="63cd0cac-bdf3-54cc-7b1f-9346ca7ac777" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -403,7 +404,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="9531e450-451a-d77b-e6c2-7a391c8049ab" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -440,7 +441,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="42132d31-b7fe-788f-ab94-390f6e406693" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <constraints>
             <constraint type="min" value="12" field="selections" scope="parent" shared="true" id="a85e-a040-19b9-3245"/>
           </constraints>
@@ -568,10 +569,10 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="03e89e63-561e-9a6c-2853-c809128f3a30" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule"/>
+        <infoLink id="03e89e63-561e-9a6c-2853-c809128f3a30" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule" name="Hatred"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4c359fa9-8570-3c9d-56b9-c03be92aa0f6" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -580,7 +581,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="b65f0ae8-d6c7-c6fb-efe3-b989d021abb3" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -593,7 +594,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="eb542e2f-5c07-65f8-8d74-a73a4bae85a0" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -606,7 +607,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup">
+            <entryLink id="44fd38ee-cf49-6b20-69b1-014f6828bab0" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases">
               <modifiers>
                 <modifier type="increment" field="minSelections" value="0"/>
               </modifiers>
@@ -624,8 +625,8 @@
           </constraints>
           <entryLinks>
             <entryLink id="17612618-33cb-0ad5-6325-cdb50c7f936f" name="Academic Skills" hidden="false" collective="false" import="true" targetId="f8cb9c64-fd91-ecfd-2e82-5ec10ec7ef53" type="selectionEntryGroup"/>
-            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup"/>
-            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup"/>
+            <entryLink id="b730009d-1a25-5605-9c34-f59b2da1cb69" hidden="false" collective="false" import="true" targetId="bd8689c9-bc5c-df7b-87b9-aad34e27a295" type="selectionEntryGroup" name="Combat Skills"/>
+            <entryLink id="9a2384e1-c454-d434-2f2c-8a881c7ebacb" hidden="false" collective="false" import="true" targetId="2a62fe9a-16ae-b087-f5a5-47f19da37c89" type="selectionEntryGroup" name="Speed Skills"/>
             <entryLink id="bc17-38e9-4027-5cb8" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="52007ee0-cc99-b312-3650-cfab391e476c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
@@ -635,7 +636,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="a7d4eb84-400b-29e8-339c-fceebcba1553" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="a7d4eb84-400b-29e8-339c-fceebcba1553" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <constraints>
             <constraint type="min" value="8" field="selections" scope="parent" shared="true" id="b7fc-69f4-c08b-6f3b"/>
           </constraints>
@@ -764,11 +765,11 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="897a9a6b-fbef-690f-78d8-886616cbbe22" hidden="false" targetId="e23bd4fb-c553-13cf-2ab8-252167663a44" type="rule"/>
-        <infoLink id="aba4bafa-4856-31af-bf3f-ab9c374b8cac" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule"/>
+        <infoLink id="897a9a6b-fbef-690f-78d8-886616cbbe22" hidden="false" targetId="e23bd4fb-c553-13cf-2ab8-252167663a44" type="rule" name="Leader"/>
+        <infoLink id="aba4bafa-4856-31af-bf3f-ab9c374b8cac" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule" name="Hatred"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="83acbe09-ec66-c45c-0f5b-1a9e0017016e-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="a359fe11-ad97-3216-79e2-42fa0fcef557" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -777,7 +778,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="265b97b3-483f-58f3-f7a4-780ba166d059" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -790,7 +791,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="4da70b4b-2903-8bb7-49aa-a8226f14561b" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -803,7 +804,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="4e184abe-fdce-287e-ab88-b98585f03810" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -829,7 +830,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="9e2cb516-6834-4a3e-ec39-9855b3d6ed2d" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry">
+        <entryLink id="9e2cb516-6834-4a3e-ec39-9855b3d6ed2d" hidden="false" collective="false" import="true" targetId="f0fc009a-7990-32ef-b84b-b631058620e2" type="selectionEntry" name="Experience">
           <constraints>
             <constraint type="min" value="20" field="selections" scope="parent" shared="true" id="3821-8808-b3fe-ec45"/>
           </constraints>
@@ -949,7 +950,7 @@
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="16763088-15c1-4f72-fdfe-153003be4a24-f9b08d8e-4922-78d5-78ad-2047bff52dc8" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true" name="Henchmen"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="579963c2-b42f-2254-f6e0-c4746cd13fc4" name="Equipment" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -958,7 +959,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="50dfad7a-35b1-bee6-657c-d603b181977d" type="selectionEntryGroup"/>
+            <entryLink id="04058374-6be1-5c6b-05d9-c5b9abf9f92c" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup" name="Equipment"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -971,7 +972,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup"/>
+            <entryLink id="361cac7b-215e-9a22-6c51-c04e043f825d" hidden="false" collective="false" import="true" targetId="36e117d8-419f-59b9-e337-512db3c6c990" type="selectionEntryGroup" name="Characteristic Increases"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -991,7 +992,7 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup"/>
+            <entryLink id="78716ad7-86df-39de-eb59-c4c01cfa1143" hidden="false" collective="false" import="true" targetId="2ace8f8f-6f26-2b7f-5407-332ed11d0355" type="selectionEntryGroup" name="Serious Injuries"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1035,7 +1036,7 @@
     </selectionEntry>
   </selectionEntries>
   <infoLinks>
-    <infoLink id="bc6ab1b0-ad56-fcef-5ed7-968f231af91b" hidden="false" targetId="bd2100cc-65f9-2311-e4b9-d0e6830884c3" type="rule"/>
+    <infoLink id="bc6ab1b0-ad56-fcef-5ed7-968f231af91b" hidden="false" targetId="bd2100cc-65f9-2311-e4b9-d0e6830884c3" type="rule" name="EXP Adancement"/>
   </infoLinks>
   <sharedSelectionEntries>
     <selectionEntry id="8acf5ee1-3430-be22-ec94-15b12e15e497" name="+1 A" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1347,7 +1348,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule"/>
+            <infoLink id="891fc816-9a6e-c06b-c2a4-bcefa6bf0972" hidden="false" targetId="3207d292-6501-25cb-d869-63b0987c78f6" type="rule" name="Avoid stun:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="10"/>
@@ -1378,7 +1379,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="796187a0-6236-3270-d63f-57b3905eab58" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="5"/>
@@ -1395,7 +1396,7 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
+            <entryLink id="9ef4302a-5af6-66e4-fb45-6b907752ccff" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="80"/>
@@ -1444,15 +1445,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry"/>
-        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry"/>
-        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry"/>
-        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry"/>
-        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry"/>
-        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry"/>
-        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry"/>
-        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry"/>
-        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry"/>
+        <entryLink id="5f33b879-84c4-0192-3962-e5f1510f30b8" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I"/>
+        <entryLink id="90e572b8-8f37-3902-7e4d-0d519d3320e9" hidden="false" collective="false" import="true" targetId="96c7d130-2a55-a926-fe7b-9ea7edc0f8a1" type="selectionEntry" name="-1 S"/>
+        <entryLink id="e57c34e4-cb6c-ca8c-a3b8-5ab15cc7a293" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS"/>
+        <entryLink id="e6f2ef6e-e9c6-5c03-e5df-4f750f71eec1" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS"/>
+        <entryLink id="a1eb369a-7395-62c1-8569-e298d930a5b6" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T"/>
+        <entryLink id="b799bf73-d1a2-3643-6c91-e2e61027dac7" hidden="false" collective="false" import="true" targetId="06c6e571-9da5-51a2-4053-aeca9035e1a2" type="selectionEntry" name="-1 A"/>
+        <entryLink id="acaee1cb-5fb9-77c7-b151-fe3877681535" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M"/>
+        <entryLink id="f53d9f32-0d34-4ee1-7489-edaaa6b9c60b" hidden="false" collective="false" import="true" targetId="043d62b3-76f8-822e-3d67-9c3806889918" type="selectionEntry" name="-1 LD"/>
+        <entryLink id="3dacaef2-0a84-fb18-9e2d-46da1f65b2f1" hidden="false" collective="false" import="true" targetId="bbd9ff4c-4aa7-432d-a143-b786400cef79" type="selectionEntry" name="-1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="36e117d8-419f-59b9-e337-512db3c6c990" name="Characteristic Increases" hidden="false" collective="false" import="true">
@@ -1467,15 +1468,15 @@ phase you may re-roll one dice when rolling on the Exploration chart. The second
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry"/>
-        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry"/>
-        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry"/>
-        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry"/>
-        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry"/>
-        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry"/>
-        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry"/>
-        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry"/>
-        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry"/>
+        <entryLink id="91ba12d9-83b5-9996-bf4d-36d7f3ccacfd" hidden="false" collective="false" import="true" targetId="0cbce569-483e-fc61-9a46-75bb7f52573a" type="selectionEntry" name="+1 I"/>
+        <entryLink id="b3bcb90d-dc4a-d879-079a-892e6dc4cd37" hidden="false" collective="false" import="true" targetId="62be0dba-2c77-76b0-3da3-48c05611f170" type="selectionEntry" name="+1 S"/>
+        <entryLink id="05840d87-e7fc-9f6e-b4be-d98f6ef21d1d" hidden="false" collective="false" import="true" targetId="b648a959-c4f1-e4dd-7f0b-7e0e9fcec205" type="selectionEntry" name="+1 WS"/>
+        <entryLink id="0a43461b-4860-a310-ca97-3639cc453a82" hidden="false" collective="false" import="true" targetId="7e03b263-c206-09f3-f9d3-47c0c9294235" type="selectionEntry" name="+1 BS"/>
+        <entryLink id="d5c24639-3822-d97d-cc82-6d5e18b39062" hidden="false" collective="false" import="true" targetId="ef8311cb-ceb9-5a7c-9d6b-9b1e0de9018d" type="selectionEntry" name="+1 T"/>
+        <entryLink id="ab62eab6-d82b-714b-7a9b-4135b49e7a12" hidden="false" collective="false" import="true" targetId="8acf5ee1-3430-be22-ec94-15b12e15e497" type="selectionEntry" name="+1 A"/>
+        <entryLink id="461ea6a4-b5be-2975-5802-0d0f3634e774" hidden="false" collective="false" import="true" targetId="492ef626-87b8-7b39-378d-38fbd1ffb131" type="selectionEntry" name="+1 M"/>
+        <entryLink id="498df122-099e-8a4f-7a1c-5b63aad30226" hidden="false" collective="false" import="true" targetId="e6a2720c-06c4-d495-d8e5-0eeb2009570a" type="selectionEntry" name="+1 LD"/>
+        <entryLink id="5be5042d-302f-7f79-20d6-ece5316b53b7" hidden="false" collective="false" import="true" targetId="a3c87526-fae5-8945-97c3-057d97df69e7" type="selectionEntry" name="+1 W"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="bd8689c9-bc5c-df7b-87b9-aad34e27a295" name="Combat Skills" hidden="false" collective="false" import="true">
@@ -1589,10 +1590,10 @@ only applies when they are armed with normal swords or weeping blades, and not w
         <constraint field="points" scope="parent" value="-1" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup"/>
-        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup"/>
-        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup"/>
-        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup"/>
+        <entryLink id="5e3bad32-8bfc-8a94-d8dc-30ef553381b9" hidden="false" collective="false" import="true" targetId="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" type="selectionEntryGroup" name="Hand to Hand Weapons"/>
+        <entryLink id="bdeec097-c1c3-0357-6493-474bb50085f4" hidden="false" collective="false" import="true" targetId="38175608-757c-9eb5-59a8-2f7b6b1019e2" type="selectionEntryGroup" name="Missile Weapons"/>
+        <entryLink id="66c22b80-dbbb-9f33-28bd-101f588861d6" hidden="false" collective="false" import="true" targetId="cd413ae9-4927-5bae-ff6e-93723ba44113" type="selectionEntryGroup" name="War Gear"/>
+        <entryLink id="453eec21-f71b-52b1-ff0e-d7a05c4600e4" hidden="false" collective="false" import="true" targetId="ab4e5484-acd3-b553-7694-5e60e6c7e3ae" type="selectionEntryGroup" name="Armor"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="b54b39f1-0daa-eabc-e0b8-74f83d2a19e0" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
@@ -1617,7 +1618,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="2903edbc-e21e-b7d5-9d6e-2d0b2101078e" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="a022bf96-d456-1fd8-41e6-fd0882f5ed93" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1628,7 +1629,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="65f97af6-c4ac-6a24-f0a3-3fd167c76ccf" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1643,7 +1644,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="1beea8a7-1b3a-bd6d-3d7f-56c31b8745eb" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1674,7 +1675,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="319ab830-e85b-038b-6c42-244e1427e054" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1689,7 +1690,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="84aa8675-4cae-ed96-ae9c-2d9b86a4730f" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1712,8 +1713,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule"/>
+            <infoLink id="cc595512-627a-9d6d-924c-f138cd14f4b8" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="dabc2113-6e8f-c846-13b3-06062efcb4a5" hidden="false" targetId="140e74d1-bf16-356b-c7d1-08b3bb5052b5" type="rule" name="Difficult To Use"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="37972d57-6f98-64fc-0e7c-cc3c30174a11" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1724,7 +1725,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="84ce2a10-2169-638f-af64-ad18b4abea67" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1739,7 +1740,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="517b922e-a3df-b54a-1b3b-f71bf5f70507" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1762,7 +1763,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule"/>
+            <infoLink id="5201fc31-a7c3-2e79-99e0-fa98833d9d37" hidden="false" targetId="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" type="rule" name="Parry"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="fcc1d76e-a482-00a0-03fb-fecd9deb538e" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1773,7 +1774,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="a4b5c477-37fe-5849-30d9-2531ecaa7ff7" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1788,7 +1789,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="37de33d5-c482-7f85-3ea0-439af226c196" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1811,8 +1812,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule"/>
-            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="830f646d-0b52-490f-e700-bd8eeeb5c604" hidden="false" targetId="a9f238c7-bf82-807c-f964-888f9c9d0f26" type="rule" name="Strike Last"/>
+            <infoLink id="b48163a2-7a87-a54e-9d24-b34d1c0b5646" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="eafc9bba-c5a2-09d3-627c-c5c102a70528" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1823,7 +1824,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="c2fa56f0-ec77-8ed4-b6ed-b2b4102b39f4" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1838,7 +1839,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="235be023-1770-b414-194e-d66425a7396d" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1861,9 +1862,9 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule"/>
-            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule"/>
-            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="8615a7d7-d7ae-0e92-7280-21b21b7860b1" hidden="false" targetId="3fa1d399-e681-411c-ebf6-c53c307e749a" type="rule" name="Strike First"/>
+            <infoLink id="b91f130e-8c7f-4540-b36a-8ed229d77b2e" hidden="false" targetId="be37b096-f38b-d3f0-0c72-f18572a56f1d" type="rule" name="Unwieldy:"/>
+            <infoLink id="8a3f73c2-103b-f779-64ac-cfa48bc470b7" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="3ef9bbbf-a875-133e-a275-fb47750ca7d8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1874,7 +1875,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="42026292-17a5-217e-f99c-25fa309b419b" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1889,7 +1890,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="58bcc84b-2f70-f600-a7b5-02a110b6e75e" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1912,7 +1913,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="76f6cf7e-4049-c81d-da4c-be4d30027e57" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="e1ae1bcf-84ef-dd9f-ae28-ed867c321df4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1923,7 +1924,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="9677837d-8238-8d25-ded3-56208a905d5e" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1938,7 +1939,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="0e5d8796-e2f4-428b-e7b8-0f20bdabc8ca" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -1964,7 +1965,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="fcb546de-38fa-3421-fddd-4352073ac0e9" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -1981,7 +1982,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule"/>
+            <infoLink id="33fa7a2a-f6cc-c44e-004f-0495c9ba8871" hidden="false" targetId="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" type="rule" name="ConCussion"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="0608e581-cb18-48b9-ab15-a1c7143f9203" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1992,7 +1993,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+                <entryLink id="f17cab57-6f45-eb8e-169c-5a7080f1ee33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2007,7 +2008,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="364edd8f-b16c-ebcf-dea7-3ae0a9566dcf" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2030,7 +2031,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule"/>
+            <infoLink id="e2261edb-c3b7-16ba-f602-c7137f1a68ce" hidden="false" targetId="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" type="rule" name="+1 Enemy armour save:"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2047,8 +2048,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule"/>
-            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule"/>
+            <infoLink id="9d2e1e1c-b04e-6e55-7cc7-626b85545e55" hidden="false" targetId="441f52ae-32a2-44f9-1784-c76c65bfd452" type="rule" name="Heavy"/>
+            <infoLink id="20da9de1-f635-f482-6628-dfb37a26c21c" hidden="false" targetId="58c7eaa3-75c5-8aad-7374-f0275b30848d" type="rule" name="Two Handed"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="aaef08ab-959e-c1cb-cce3-c9409cfc73c2" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2059,7 +2060,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="e6d5fafd-f13c-ae9e-547f-8798c51b628c" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2074,7 +2075,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="ccbf5b4d-a438-9450-3f80-2b30c9bd9d0a" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2097,8 +2098,8 @@ only applies when they are armed with normal swords or weeping blades, and not w
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule"/>
-            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule"/>
+            <infoLink id="b8259800-cc41-431e-be71-16c66412323e" hidden="false" targetId="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" type="rule" name="Cavalry Weapon"/>
+            <infoLink id="46536962-cd5f-ed27-0f2e-c50558d89db5" hidden="false" targetId="c0c80c24-1dc8-7adc-c069-8917b30bffcd" type="rule" name="Cavalry bonus"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="50469495-65e4-8313-fb4a-b47e3f3d4e5d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -2109,7 +2110,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule"/>
+                <infoLink id="86c39759-8365-3e28-c22c-6b990895e161" hidden="false" targetId="6549136a-9a00-4d3a-b8fa-ecadf63e4744" type="rule" name="Gromril weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2124,7 +2125,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule"/>
+                <infoLink id="8a29de49-1b00-b754-95fe-38caf12ea51b" hidden="false" targetId="05584e01-dfb3-7e17-b3ba-279aba211018" type="rule" name="Ithilmar weapon"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0"/>
@@ -2288,8 +2289,8 @@ a duelling pistol have a +1 bonus to hit.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
-            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
+            <infoLink id="174577f9-4df4-b461-5c68-774bddd28e1a" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
+            <infoLink id="8d606396-a57a-a055-7179-273191fac276" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -2307,7 +2308,7 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="75b70afd-e04c-c597-2082-77fa1b59d80b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2325,9 +2326,9 @@ a duelling pistol have a +1 bonus to hit.</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule"/>
-            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule"/>
-            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule"/>
+            <infoLink id="ff44c56f-6d6a-53b9-4ea9-676458a5bd9e" hidden="false" targetId="f7723056-9cfe-c405-d7e6-357321f7dca3" type="rule" name="Prepare shot"/>
+            <infoLink id="965861ef-e2d3-2114-8fc1-83d97d0b0b96" hidden="false" targetId="da91afee-2f0d-cbc1-78ff-c6bdec885712" type="rule" name="Move Of Fire"/>
+            <infoLink id="aeea8cc7-4ae8-a66c-747d-a85a162db224" hidden="false" targetId="a3327e94-8ff2-b189-9303-34c54c57373f" type="rule" name="Gun Save modifier"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -2570,7 +2571,7 @@ The power of the Armour of Righteousness lasts until the beginning of the Priest
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="f0bf7b17-b2a9-e6b0-ce05-d19f0700aedb" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2594,7 +2595,7 @@ The power of the Armour of Righteousness lasts until the beginning of the Priest
         </selectionEntry>
         <selectionEntry id="d7277e6e-49d8-50cb-988c-84bb7240da31" name="Maddness: Stupidity" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule"/>
+            <infoLink id="03ca68f4-c714-1811-6183-179c17af9aa9" hidden="false" targetId="cd0edb82-a80c-4679-2376-f34a11dc840e" type="rule" name="Stupidity"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2603,7 +2604,7 @@ The power of the Armour of Righteousness lasts until the beginning of the Priest
         </selectionEntry>
         <selectionEntry id="abc70d10-8ad7-23a1-6eb0-e05474350e3f" name="Madness: Frenzy" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule"/>
+            <infoLink id="2405cb62-5f89-ae77-e992-d849386a7dae" hidden="false" targetId="abb6f4c1-7058-c49a-c0df-9dfacb18d599" type="rule" name="Frenzy"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -2617,7 +2618,7 @@ The power of the Armour of Righteousness lasts until the beginning of the Priest
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="a998bfe9-42c1-0763-0747-e1c851080e15" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2636,7 +2637,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry">
+            <entryLink id="30324a76-6c80-b2e4-7879-3f9fbddefe9f" hidden="false" collective="false" import="true" targetId="a93c5e1e-9169-8d09-5cba-5aa094184fe1" type="selectionEntry" name="-1 BS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2665,7 +2666,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="d7d5e798-2fbc-8704-e69c-61113a0c1bb2" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2683,7 +2684,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="0ed1495c-3cd6-e312-8087-84a1945b4a56" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
                 <modifier type="set" field="minSelections" value="1"/>
               </modifiers>
@@ -2723,7 +2724,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+            <infoLink id="1a02c0ba-c1e9-bfb6-c550-bb4f5146c775" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule" name="Fear"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3170,7 +3171,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="71020939-8649-86e5-e688-1ee924e46b53" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3184,7 +3185,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="1c3487eb-bcce-e97b-ee82-efd7781a89d5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3198,7 +3199,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="4e5f7880-a51f-cf25-84c8-ab558e9dbcd5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3212,7 +3213,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b7636e08-2b2b-d34a-0549-642de0c3ad33" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3229,7 +3230,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="efa0c4e1-d3e5-3089-c64d-c3927315d85b" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3243,7 +3244,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b6ccfa23-782b-0286-2654-b56752d2f2b0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3257,7 +3258,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="32229f36-5fea-e8ac-ce8c-054f8ef18eca" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="100"/>
@@ -3282,7 +3283,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="db96c5bc-a151-5aea-b28c-b48e4a30b47c" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="30"/>
@@ -3296,7 +3297,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="25f76104-f8fa-7b77-86c3-a56086506682" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="20"/>
@@ -3310,7 +3311,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="65c1c273-dc16-298a-8a68-d5d943378ee2" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3324,7 +3325,7 @@ Side effects: After the battle, roll 2D6. On a roll of 2-3, the model becomes ad
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="35149235-b9a7-0f4a-253d-6d687eec4459" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3365,7 +3366,7 @@ You may mount one of your Heroes on a horse  in the coming battles. Horses  can 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="f16ad40b-2a02-da55-dc5a-130140022ff7" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3417,7 +3418,7 @@ Side effects: Mandrake Root is highly poisonous. At the end of the battle, roll 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="c5c68411-eb22-3164-4bf7-dcbbb06435b6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="25"/>
@@ -3445,7 +3446,7 @@ on the Exploration chart as long as the Hero who possesses this map was not take
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="a6a95389-0057-3875-8a46-d563896c64c4" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3493,7 +3494,7 @@ model’s BS to determine whether the net hits or not – there are no movement 
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="443ce069-05dc-9940-1387-169e88dad9f6" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3550,7 +3551,7 @@ Wardogs count towards the maximum number of warriors allowed in your warband.</d
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="56bc022e-bf29-afb3-0425-73738a9d19e5" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3578,7 +3579,7 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="760e1570-5e4b-e06a-7ada-6f173c1afc98" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3592,7 +3593,7 @@ Side effect: After the battle, roll a D6. On a roll of a 1 the model becomes per
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry"/>
+            <entryLink id="b8af3d73-5744-2659-88a0-2bfbb5a55da0" hidden="false" collective="false" import="true" targetId="b39ee84c-3f79-227e-4b39-8469fb19d56a" type="selectionEntry" name="Gold"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0"/>
@@ -3692,4 +3693,7 @@ combat, roll a D6.
       <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="common-data" id="45b6-f7d7-5e74-3e3a" targetId="e020-c282-277b-b173"/>
+  </catalogueLinks>
 </catalogue>

--- a/common-data.cat
+++ b/common-data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e020-c282-277b-b173" name="common-data" revision="20" battleScribeVersion="2.03" library="true" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="e020-c282-277b-b173" name="common-data" revision="21" battleScribeVersion="2.03" library="true" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry id="d769-0d85-e810-df60" name="Experience" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
@@ -2686,6 +2686,201 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
         <infoLink name="Parry" id="c068-9967-a764-ae12" hidden="false" type="rule" targetId="17dc-9c49-08e1-af45"/>
       </infoLinks>
     </selectionEntry>
+    <selectionEntry id="394f-a580-a345-e1ad" name="Caltrops" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="9c83-d40e-12ec-ba33" name="Caltrops" page="0" hidden="false">
+          <description>There are enough caltrops to last for one use only. They may be used when an opponent decides to charge. The defender simply throws the caltrops into the path of his attacker and they reduce his charge range by D6 inches. If this means that the attacker cannot reach his target then it is a failed charge.</description>
+        </rule>
+        <rule id="3b3b-b88f-615c-d38d" name="Rarity" hidden="false">
+          <description>Rarity 6</description>
+        </rule>
+        <rule name="Price Modifier" id="9f2d-d96b-7098-de13" hidden="false">
+          <description>2D6</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="15"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="8293-c01a-9fab-9054" name="Banner" page="Opulent Goods, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="ff7a-9aca-e5e1-0347" name="Banner" page="0" hidden="false">
+          <description>A banner requires one hand to use and can be carried by any Hero in the warband. Friendly warriors within 12&quot; of the banner bearer may re-roll any failed &apos;All Alone&apos; test; but remember, you can&apos;t re-roll a failed re-roll.</description>
+        </rule>
+        <rule id="521d-2ae6-2eb4-f923" name="Rarity" hidden="false">
+          <description>Rarity 5</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="10"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="d16f-0904-21e5-158b" name="Fire Bomb" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="bb96-1f9d-814a-49eb" name="Fire Bomb" page="0" hidden="false">
+          <description>The fire bomb may be thrown in the shooting phase in the same way as blessed water (see p53 Mordheim rule book). If the bomb lands on target the warrior hit takes D3 Strength 4 hits with no saves for armour and all warriors, friend or foe, within 1 inch of him take 1 Strength 3 hit with saves as normal. If the throwing warrior rolls a 1 when rolling to hit the bomb misfires and explodes just as if the throwing warrior had been hit by his own fire bomb!</description>
+        </rule>
+        <rule id="e7b8-34fa-20df-0e85" name="Rarity" hidden="false">
+          <description>Rarity 9</description>
+        </rule>
+        <rule name="Price Modifier" id="92f6-c19f-331f-9d5f" hidden="false">
+          <description>2D6</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="35"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="e15c-e780-cf64-8bee" name="Flash Powder" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="c182-567a-d561-3915" name="Flash Powder" page="0" hidden="false">
+          <description>Flash powder can be thrown as an enemy charges the wielder (as an interrupt). The charger must take an immediate Initiative test in order to cover their eyes. If he fails, he is temporarily blinded and it counts as a failed charge. There is only enough flash powder for one use during the battle.</description>
+        </rule>
+        <rule id="138e-ee6b-b4ef-22ef" name="Rarity" hidden="false">
+          <description>Rarity 8</description>
+        </rule>
+        <rule name="Price Modifier" id="a98b-18f5-741b-425c" hidden="false">
+          <description>2D6</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="25"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="2aa9-cf76-c0fc-686c" name="Lock Picks" page="Empire in Flames supplement (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="d5f9-382a-1a21-e962" name="Lock Picks" page="0" hidden="false">
+          <description>A model equipped with a set of lock picks may make his test to open doors on his Initiative rather than his Strength characteristic if he wishes. This is done at the end of his Movement phase as if the model were ripping the door off its hinges, though he uses his Initiative rather than Strength, there is no -1 modifier, and there is no chance that the door is too damaged to be locked again later.</description>
+        </rule>
+        <rule id="b6a1-4a9e-8f8e-1960" name="Rarity" hidden="false">
+          <description>Rarity 8</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="15"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="b7ee-595e-9530-2c67" name="Fire Arrows" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="3c41-d31e-a6e9-8a2a" name="Fire Arrows" page="0" hidden="false">
+          <description>If you hit with a fire arrow roll a D6. If you score a 4+ your opponent has been set on fire. They must roll a D6 in the recovery phase and score a 4+ to put themselves out or they will suffer a strength 4 hit and will be unable to do anything other than move for each turn they are on fire. Allies may also attempt to put the warrior out. They must be in base contact and need a 4+ to be successful. The fire arrows last for one battle only.</description>
+        </rule>
+        <rule id="62a3-31bf-38f6-2127" name="Rarity" hidden="false">
+          <description>Rarity 9</description>
+        </rule>
+        <rule name="Price Modifier" id="5d82-9cc8-3c9c-bb3f" hidden="false">
+          <description>D6</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="30"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="86a9-a953-4354-8ab3" name="Hammer of Witches" page="Opulent Goods, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="3fb2-92bb-8ccc-5346" name="Hammer of Witches" page="0" hidden="false">
+          <description>A Hero with the Hammer of Witches will hate all Possessed, Skaven, Beastmen, Chaos, Daemons, Dark Elf, Orc &amp; Goblins and Sigmarite Sisters.</description>
+        </rule>
+        <rule id="8c67-6775-658e-a4dc" name="Rarity" hidden="false">
+          <description>Rarity 10 (Witch Hunters only)</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="100"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="1410-6d05-7ae1-bf81" name="Rabbit&apos;s Foot" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="ff84-1218-233a-2d70" name="Rabbit&apos;s Foot" page="0" hidden="false">
+          <description>A rabbit&apos;s foot allows the warrior wearing it to reroll one dice during the battle. If not used in the battle it can be used to reroll one dice during the exploration phase providing the hero is able to search through the ruins.</description>
+        </rule>
+        <rule id="1104-bad9-c53c-1a3f" name="Rarity" hidden="false">
+          <description>Rarity 5</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="10"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="dc4a-3b9c-3c3e-72cd" name="Tarot Cards" page="Opulent Goods, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="42ad-47ea-1e82-a052" name="Tarot Cards" page="0" hidden="false">
+          <description>A Hero with a deck of tarot cards may consult them before each game. Make a Leadership test. If successful, the Hero gains a favorable insight into the future and you may modify the result of any one dice in the Exploration phase by -1/+1 (even if the Hero with the cards is taken Out Of Action). If the Leadership test is failed by three or more (i.e., a Hero with Ld of 8 rolls 11 or 12) the cards show a portent of doom and despair and the Hero refuses to fight in the following battle and must miss the next game.</description>
+        </rule>
+        <rule id="1f0d-e703-cd15-f0a3" name="Rarity" hidden="false">
+          <description>Rare 7 (Not available to Witch Hunters or Sisters of Sigmar)</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="50"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="b627-8e25-4817-ab22" name="Wyrdstone Pendulum" page="Opulent Goods, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="48ca-34f7-50ae-83d2" name="Wyrdstone Pendulum" page="0" hidden="false">
+          <description>If he was not taken out, the Hero using the Wyrdstone Pendulum may make a Leadership test after the battle. If he is successful, you may re-roll any one dice in the Exploration phase. This dice may not be re-rolled</description>
+        </rule>
+        <rule id="4e9d-55ac-79bc-fde5" name="Rarity" hidden="false">
+          <description>Rare 9</description>
+        </rule>
+        <rule name="Price Modifier" id="bac0-83af-6016-9d62" hidden="false" page="3D6"/>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="25"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="356d-ccef-3ec2-5c04" name="Telescope" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="e4d4-80a4-5d82-1b2e" name="Telescope" page="0" hidden="false">
+          <description>Any hero using a telescope may increase the range of any missile weapon he is using by D6 inches each turn. Furthermore, he triples the distance at which he can spot hidden enemies.</description>
+        </rule>
+        <rule id="dff8-18d7-ef1e-b580" name="Rarity" hidden="false">
+          <description>Rare 10</description>
+        </rule>
+        <rule name="Price Modifier" id="2900-35df-9e92-5b2a" hidden="false" page="3D6"/>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="75"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
+    <selectionEntry id="4e09-c82c-1bd9-081d" name="War Horn" page="Ye Old Curiosity Shoppe, Mordheim Annual 2002 (1a)" hidden="false" collective="false" import="true" type="upgrade">
+      <rules>
+        <rule id="8f15-ee5e-e940-7988" name="War Horn" page="0" hidden="false">
+          <description>A war horn may be used once per battle at the beginning of any turn. It allows the warband to increase its Leadership by +1. The effect will last from the start of one turn to the start of the next. The war horn can be used just before a warband is about to take a rout test.</description>
+        </rule>
+        <rule id="fe9c-5451-686b-1671" name="Rarity" hidden="false">
+          <description>Rare 8</description>
+        </rule>
+        <rule name="Price Modifier" id="a286-152c-f633-1235" hidden="false" page="2D6"/>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="30"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
+      <comment>1a</comment>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="df9d-8724-d362-9d7c" name="Academic Skills" hidden="false" collective="false" import="true">
@@ -3417,6 +3612,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         <entryLink id="b1e6-5b0e-41d7-eeaf" name="Claw of the Old Ones" hidden="false" collective="false" import="true" targetId="993b-b4c4-118f-3ce3" type="selectionEntry"/>
         <entryLink import="true" name="Pike" hidden="false" id="9f83-3b50-5491-90f2" type="selectionEntry" targetId="68ec-2a33-6ca8-d146"/>
         <entryLink import="true" name="Boat Hook" hidden="false" id="355b-13e-2e5b-921c" type="selectionEntry" targetId="8bf0-e215-6bbb-383e"/>
+        <entryLink import="true" name="Free Dagger" hidden="false" id="60c9-4e5b-0040-dd65" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="1937-df4f-3c68-e0be" name="Missile Weapons" hidden="false" collective="false" import="true">
@@ -3756,6 +3952,7 @@ must retire from the warband.</description>
           </entryLinks>
         </entryLink>
         <entryLink id="dc31-0d77-4ab1-91b9" name="Miscellaneous Equipment" hidden="false" collective="false" import="true" targetId="a2cf-6f28-f7c2-275d" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Miscellaneous Equipment (1a)" hidden="false" id="00ff-dc02-4a1b-02d9" type="selectionEntryGroup" targetId="27a7-c1bf-0c40-ff21"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="5541-f5c4-85e0-b399" name="Mutations" hidden="false" collective="false" import="true">
@@ -4285,6 +4482,26 @@ Warriors without Ride may not use this skill.</description>
           </rules>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="27a7-c1bf-0c40-ff21" name="Miscellaneous Equipment (1a)" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f49-b067-d129-cd74" type="min"/>
+      </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Banner" hidden="false" id="096d-afa4-480c-6947" collective="false" targetId="8293-c01a-9fab-9054" type="selectionEntry" page="Opulent Goods, Mordheim Annual 2002 (1a)"/>
+        <entryLink import="true" name="Caltrops" hidden="false" id="3ca4-67c7-fd0d-b9f2" type="selectionEntry" targetId="394f-a580-a345-e1ad"/>
+        <entryLink import="true" name="Fire Arrows" hidden="false" id="8232-874b-0070-dc1b" type="selectionEntry" targetId="b7ee-595e-9530-2c67"/>
+        <entryLink import="true" name="Fire Bomb" hidden="false" id="3586-5d6c-524e-0f22" type="selectionEntry" targetId="d16f-0904-21e5-158b"/>
+        <entryLink import="true" name="Flash Powder" hidden="false" id="4cf0-90f5-244f-ba14" type="selectionEntry" targetId="e15c-e780-cf64-8bee"/>
+        <entryLink import="true" name="Hammer of Witches" hidden="false" id="f277-53fc-027e-7625" type="selectionEntry" targetId="86a9-a953-4354-8ab3"/>
+        <entryLink import="true" name="Lock Picks" hidden="false" id="61f2-2a6d-5bb3-36ba" type="selectionEntry" targetId="2aa9-cf76-c0fc-686c"/>
+        <entryLink import="true" name="Rabbit&apos;s Foot" hidden="false" id="0112-63ba-cdb6-06fc" type="selectionEntry" targetId="1410-6d05-7ae1-bf81"/>
+        <entryLink import="true" name="Tarot Cards" hidden="false" id="c0ad-983e-d137-3a81" type="selectionEntry" targetId="dc4a-3b9c-3c3e-72cd"/>
+        <entryLink import="true" name="Telescope" hidden="false" id="c726-03ed-de31-4a55" type="selectionEntry" targetId="356d-ccef-3ec2-5c04"/>
+        <entryLink import="true" name="War Horn" hidden="false" id="8d13-4408-6331-588a" type="selectionEntry" targetId="4e09-c82c-1bd9-081d"/>
+        <entryLink import="true" name="Wyrdstone Pendulum" hidden="false" id="7b7a-ec7c-1d99-454e" type="selectionEntry" targetId="b627-8e25-4817-ab22"/>
+        <entryLink import="true" name="Torch" hidden="false" id="f2b9-2aa8-28fe-02ea" type="selectionEntry" targetId="065e-ad0a-c227-a634"/>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>


### PR DESCRIPTION
All who use common data equipment list will get a new group with 1a Miscellaneous items.
1a Warbands will use common-data Equipment list rather then their own equipment list for easier updates with new items,