### PR TITLE
Bug fix update

### DIFF
--- a/Amazons_Lustria.cat
+++ b/Amazons_Lustria.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c0ee-cf6e-9b18-45b6" name="Amazons Lustria (1b)" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="c0ee-cf6e-9b18-45b6" name="Amazons Lustria (1b)" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="c766-4c9f-c70c-d00a" name="GitHub" publisherUrl="https://github.com/BSData/mordheim.git"/>
   </publications>
@@ -1223,6 +1223,45 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="4841-a339-6a7b-4a98" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="e402-d2b1-545f-f4a4" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="1f2b-38f5-f898-c235-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="1f2b-38f5-f898-c235-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Isolationists" id="b145-8eae-7e23-4843" hidden="false">
+          <description>The Amazons are constantly battling against the predations of the Lizardmen and greedy treasure-seeking Norse.
+Amazon culture reflects their dislike and distrust of outsiders and in battle they are particularly savage.
+
+Amazons get to re-roll any attack rolls that miss in the first round of combat against Lizardmen and Norse.</description>
+        </rule>
+        <rule name="Norse Enmity" id="08bf-9b27-fe06-1d9a" hidden="false">
+          <description>When facing a Norse Warband an Amazon Warband will fight to the death.
+
+The Amazons can re-roll their first failed Rout against the Norse.
+Remember you can’t re-roll a failed re-roll. 
+
+In addition, Amazons can never choose to voluntarily rout when facing a Norse warband unless their Warband Leader has been taken Out of Action.</description>
+        </rule>
+        <rule name="Not one of us" id="8eeb-64b9-bf4c-6f9b" hidden="false">
+          <description>Due to the Amazons isolationism and suspicions about other races they never side with anyone else.
+
+For this reason, the Amazons may not have any Hired Swords or Dramatis Personae unless they are Amazons themselves.</description>
+        </rule>
+        <rule name="Sacrifice" id="9b01-d7cc-330f-4312" hidden="false">
+          <description>The Amazons are quick to sacrifice any captive to their gods.
+The Amazons follow the rules for Possessed in the Rulebook when it comes to captives.
+
+If an Amazon Warband captures a Lizardman, they may sacrifice him as normal, plus get a free Skins and Charms.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="57f9-5fdc-127e-f964" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <rules>
     <rule id="cc65-53b2-ceba-cf3d" name="Isolationists" hidden="false">
@@ -1608,15 +1647,4 @@ Lizardmen and Undead are immune to the effects of this ritual.</characteristic>
   <catalogueLinks>
     <catalogueLink id="721b-9624-66b8-f3a6" name="common-data" targetId="e020-c282-277b-b173" type="catalogue" importRootEntries="true"/>
   </catalogueLinks>
-  <entryLinks>
-    <entryLink import="true" name="Grade" hidden="false" id="1743-28bf-c7fc-1d16" type="selectionEntryGroup" targetId="3394-366e-74c0-2277">
-      <categoryLinks>
-        <categoryLink targetId="4852-c4cb-82b0-b7fa" id="6685-e23a-8fdf-ddf6" primary="true" name="Configuration"/>
-      </categoryLinks>
-      <constraints>
-        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="791e-2684-0b08-e047-min"/>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="791e-2684-0b08-e047-max"/>
-      </constraints>
-    </entryLink>
-  </entryLinks>
 </catalogue>

--- a/Amazons_Mordheim.cat
+++ b/Amazons_Mordheim.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f2c-337f-3ebd-2263" name="Amazons Mordheim (1b)" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="7f2c-337f-3ebd-2263" name="Amazons Mordheim (1b)" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="8b30-e6c9-483c-6fa7" name="Priestess" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -124,7 +124,7 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <infoLink id="9d60-54ec-14f2-1f33" name="Leader" hidden="false" targetId="8712-d0f2-fe64-07bd" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c6ca-2011-b22b-a558" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="c6ca-2011-b22b-a558" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="bb19-362c-651e-2017" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -290,7 +290,7 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <infoLink id="7573-32e5-0091-58b9" name="Frenzy" hidden="false" targetId="ce28-23a1-7b2a-7e6c" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="dc79-d0f6-09aa-5219" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="dc79-d0f6-09aa-5219" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c144-769c-b2dd-efc4" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -452,7 +452,7 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <infoLink id="d07a-caf3-2cf0-e3c1" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4761-52f6-7a68-5591" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="4761-52f6-7a68-5591" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1a12-85bd-2396-ee42" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -614,7 +614,7 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <infoLink id="1b94-8ffb-1d0a-cdec" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9771-898c-4bd2-17f5" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="9771-898c-4bd2-17f5" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="63af-1cba-f53d-14a2" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -780,7 +780,7 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <infoLink id="c8fa-82e9-5eab-06d0" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5cda-8dff-d861-8cca" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="5cda-8dff-d861-8cca" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fe1d-a309-97fe-2160" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -832,17 +832,45 @@ She starts with 1 ritual chosen at random from the list over.</description>
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c659-a664-8515-0a34" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="6025-beba-5e03-42c9" name="New CategoryLink" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="6025-beba-5e03-42c9" name="Stash" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="a673-f4cf-b1ee-af92" name="Gold" hidden="false" collective="false" import="true" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink id="a673-f4cf-b1ee-af92" name="Variable Gold Cost" hidden="false" collective="false" import="true" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink id="6c73-1d64-5123-0918" name="Wyrdstone" hidden="false" collective="false" import="true" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
-        <entryLink id="2710-26af-c8d9-8800" name="Looted Equip" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
+        <entryLink id="2710-26af-c8d9-8800" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="1251-1c71-a66b-c872" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="c22f-e85f-222c-ed14" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="fca1-2e52-58a8-016f-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="fca1-2e52-58a8-016f-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Not one of us" id="96dd-96ca-fce8-d2af" hidden="false">
+          <description>Due to the Amazons isolationism and suspicions about other races they never side with anyone else.
+
+For this reason, the Amazons may not have any Hired Swords or Dramatis Personae unless they are actually Amazons themselves.</description>
+        </rule>
+        <rule name="Sacrifice" id="b153-9474-f614-a497" hidden="false">
+          <description>The Amazons are quick to sacrifice any captive to their gods.
+
+The Amazons follow the rules for Possessed in the Rulebook when it comes to captives.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="d5a2-8ce3-793b-ff89" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>
@@ -991,7 +1019,7 @@ Lizardmen and Undead are immune to the effects of this ritual.</characteristic>
       <entryLinks>
         <entryLink id="0b35-6b54-95e7-ad8e" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
         <entryLink id="cda1-95a5-b50e-064e" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
-        <entryLink id="40b9-188f-7ba3-cc16" name="Hammer, staff, mace or club" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+        <entryLink id="40b9-188f-7ba3-cc16" name="Hammer" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="name" value="Club"/>
           </modifiers>
@@ -1051,7 +1079,7 @@ Lizardmen and Undead are immune to the effects of this ritual.</characteristic>
       <entryLinks>
         <entryLink id="75ef-c59d-a647-8800" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
         <entryLink id="5fb5-5c4e-f438-5987" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
-        <entryLink id="b524-2bd5-78cb-96b9" name="Hammer, staff, mace or club" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+        <entryLink id="b524-2bd5-78cb-96b9" name="Hammer" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="name" value="Club"/>
           </modifiers>
@@ -1090,7 +1118,7 @@ Lizardmen and Undead are immune to the effects of this ritual.</characteristic>
       <entryLinks>
         <entryLink id="911d-aade-ca94-c15c" name="Sling" hidden="false" collective="false" import="true" targetId="87c7-49b5-f1e7-6662" type="selectionEntry"/>
         <entryLink id="9272-a6fd-2a73-624a" name="Bow" hidden="false" collective="false" import="true" targetId="311a-bf3f-67ff-46e7" type="selectionEntry"/>
-        <entryLink id="999a-f29c-f3b5-366f" name="Javelins/Harpoons" hidden="false" collective="false" import="true" targetId="ece5-fffa-8dd8-94dc" type="selectionEntry">
+        <entryLink id="999a-f29c-f3b5-366f" name="Javelins" hidden="false" collective="false" import="true" targetId="ece5-fffa-8dd8-94dc" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="name" value="Javelins"/>
           </modifiers>

--- a/Arabian Tomb Raiders.cat
+++ b/Arabian Tomb Raiders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="15c7-6ea-37ea-739d" name="Arabian Tomb Raiders (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="15c7-6ea-37ea-739d" name="Arabian Tomb Raiders (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="b80c-d8ab-a18d-bc37" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -983,6 +983,24 @@ Note that you only get +1 even if you have two Bedouins.</description>
         <constraint type="max" value="2" field="selections" scope="roster" shared="true" id="48f-e47a-6f47-2205"/>
       </constraints>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="603c-3267-49e2-c9ce" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3c38-0dd2-b796-66d5" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="089f-cbfc-66c0-5481-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="089f-cbfc-66c0-5481-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hate Undead" id="a594-9a57-d97a-1949" hidden="false">
+          <description>The men of Araby have suffered heavily at the hands (or should that be claws!) of the Tomb King’s armies of the Land of the Dead.
+Therefore Arab Heroes hate all Undead.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="479b-23e0-7d3f-33f1" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Warrior Equipment" hidden="false" id="7514-894c-6f35-8354">
@@ -996,7 +1014,7 @@ Note that you only get +1 even if you have two Bedouins.</description>
       <entryLinks>
         <entryLink id="aa9d-a0c5-4294-c91e" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
         <entryLink id="ac7c-5c83-3682-3db8" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
-        <entryLink id="4d3b-e1c8-c2cc-917f" name="Hammer, staff, mace or club" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+        <entryLink id="4d3b-e1c8-c2cc-917f" name="Hammer" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="name" value="Mace"/>
           </modifiers>
@@ -1037,7 +1055,7 @@ Note that you only get +1 even if you have two Bedouins.</description>
         <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="4d37-f97f-cefc-c9bd" targetId="74fb-cc90-1361-df26"/>
         <entryLink import="true" name="Buckler" hidden="false" type="selectionEntry" id="6583-1dd0-8ad6-cedb" targetId="0871-44c2-f0f0-c27a"/>
         <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="c301-1f58-6b8-ba22" targetId="d0e5-ca89-5f0d-f5d2"/>
-        <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="1747-fa9c-f53a-bcfa" targetId="3d2a-426a-c350-2a03"/>
+        <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="1747-fa9c-f53a-bcfa" targetId="3d2a-426a-c350-2a03"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup name="Slave Equipment" hidden="false" id="d761-2c37-952a-2f3e">
@@ -1050,7 +1068,7 @@ Note that you only get +1 even if you have two Bedouins.</description>
       <entryLinks>
         <entryLink id="3282-5c0-4191-4d2e" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
         <entryLink id="2f3e-6d61-a97d-cba" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
-        <entryLink id="9b2d-2083-13e0-6369" name="Hammer, staff, mace or club" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+        <entryLink id="9b2d-2083-13e0-6369" name="Hammer" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="name" value="Club"/>
           </modifiers>

--- a/Averlander_Mercenary.cat
+++ b/Averlander_Mercenary.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="49df-928f-1fa4-ff5b" name="Averlanders (1a)" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="49df-928f-1fa4-ff5b" name="Averlanders (1a)" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="692a-ce2e-7624-f850" name="Averlander Mercenary Rules" shortName="Averlander Mercenary Rules" publisher="https://broheim.net/downloads/warbands/official/Averland%20Mercenaries.pdf" publisherUrl="https://broheim.net"/>
   </publications>
@@ -1934,6 +1934,18 @@ Halflings are not known for their great strength!</description>
           </modifiers>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="607b-5b35-42ad-b64b" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="85aa-f1d8-ea4b-cb11" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="f4a3-19d1-f855-06a2-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="f4a3-19d1-f855-06a2-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="dc48-ffb5-9872-0106" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>

--- a/Battle Monks of Cathay.cat
+++ b/Battle Monks of Cathay.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="4cde-fbe1-d53-81d1" name="Battle Monks of Cathay (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="4cde-fbe1-d53-81d1" name="Battle Monks of Cathay (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="2085-9795-666b-65cf" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -37,7 +37,7 @@
         <selectionEntryGroup name="Missile Weapons" id="626a-4ada-d264-73b" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Handgun" hidden="false" id="994e-1634-55a-948c" collective="false" targetId="7f5a-d04d-153d-d334" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="1652-b8b0-5718-b558" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="1652-b8b0-5718-b558" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
@@ -51,10 +51,10 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="d3fc-126d-4fe5-a3f9" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="ff48-87b5-1d83-73c8" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="ff48-87b5-1d83-73c8" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="430b-dd28-4f1e-7ba7" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="1627-bb9a-f46a-89a5" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="a9ed-305b-94b2-c8c2" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="a9ed-305b-94b2-c8c2" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup name="Miscellaneous Equipment" id="a7b8-2cc1-8ba6-47df" hidden="true">
@@ -2352,7 +2352,11 @@ The model is immediately taken out of action.</description>
         <categoryLink name="Stash" hidden="false" id="24a6-be66-7314-ac9e" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="aedd-4f11-98c9-6a" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="aedd-4f11-98c9-6a" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="4c00-f2e1-25d9-6ea9" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="5c93-c3e5-27af-c68a" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2360,6 +2364,39 @@ The model is immediately taken out of action.</description>
         <cost name="pts" id="c96d-b86f-261c-3d05" hidden="false" typeId="points" value="0"/>
         <cost name="Warband Rating" id="5138-9a98-8d3e-c73a" hidden="false" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="6aab-1ffc-4d14-8a59" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="49b4-d5bf-05cc-b6f9" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="d088-731c-e3ea-77c8-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="d088-731c-e3ea-77c8-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Distaste for Poison" id="9cc9-e5c8-f86a-194d" hidden="false">
+          <description>The use of poisons and various drugs is a speciality for dishonourable warriors who would stoop to such ends.
+
+
+Dragon Monks and Warrior Monks frown on this and may never use any kind of poison or venom.</description>
+        </rule>
+        <rule name="Outsiders" id="58a5-ac18-8c0b-c8e3" hidden="false">
+          <description>Foreigners are generally considered unwelcome by the border guards of Cathay. 
+
+
+The Battle Monks warband may never hire any sort of Hired Sword or Dramatis Personae unless specifically stated with the Hired sword/Dramatis Personae.</description>
+        </rule>
+        <rule name="Strictures" id="3e85-458b-ca62-a766" hidden="false">
+          <description>A stringent regime of meditation is used by monks.
+Their faith is supported by a notion that the skin of ones body is armor in itself. 
+
+
+Dragon Monks and Warrior Monks never wear any kind of armor.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="e71f-cbf6-5352-ef9f" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Beastmen_Raiders.cat
+++ b/Beastmen_Raiders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e783-91c9-0f57-a7bb" name="Beastmen Raiders (1a)" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="e783-91c9-0f57-a7bb" name="Beastmen Raiders (1a)" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="b758-ee46-f27e-58dd" name="Beastman Rules" shortName="Beastman" publisher="https://broheim.net/downloads/warbands/unofficial/Beastmen%2C%20Errata%27d.pdf" publisherUrl="https://broheim.net/downloads/warbands/unofficial/Beastmen%2C%20Errata%27d.pdf"/>
   </publications>
@@ -1795,7 +1795,11 @@ If an Ungor rolls ‘That lad’s got talent’ it must be re-rolled.</descripti
         <categoryLink id="d8ea-09b6-df01-6a26" name="Stash" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="16b7-704b-249a-4199" name="Variable Gold Cost" hidden="false" collective="false" import="true" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink id="16b7-704b-249a-4199" name="Variable Gold Cost" hidden="false" collective="false" import="true" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink id="e743-b303-078d-580e" name="Wyrdstone" hidden="false" collective="false" import="true" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink id="04c3-6648-7241-e5c1" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -1803,6 +1807,25 @@ If an Ungor rolls ‘That lad’s got talent’ it must be re-rolled.</descripti
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="b8db-dcfd-4c54-05df" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="e179-0819-86ae-edc9" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="5810-e37e-27a9-c621-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="5810-e37e-27a9-c621-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Animals" id="e974-7178-6b5f-89d4" hidden="false">
+          <description>Beastmen are fearsome creatures of Chaos that do not interact with other races other than in war.
+
+A Beastmen warband may never hire any Hired Swords unless specifically stated with the Hired Sword.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="2dd7-280c-b442-305e" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Black Dwarfs.cat
+++ b/Black Dwarfs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6e90-f47-6d8f-ecf5" name="Black Dwarfs (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6e90-f47-6d8f-ecf5" name="Black Dwarfs (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="a72c-9e0b-9f94-25a4" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -31,7 +31,7 @@ They may never hire Elves of any sort!</description>
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="996e-24a4-38db-696f" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry" sortIndex="2"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="3b01-fcf0-cfa6-f06d" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry" sortIndex="1"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="8379-c2b7-8521-8378" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="8379-c2b7-8521-8378" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -93,10 +93,10 @@ They may never hire Elves of any sort!</description>
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="bbc7-6300-ffe7-a5b" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="a8dd-2993-6deb-f0b" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="a8dd-2993-6deb-f0b" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="4b62-461b-a9ee-64fa" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="3"/>
             <entryLink import="true" name="Helmet" hidden="false" id="672b-c28f-5a84-498c" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2" sortIndex="4"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="92ff-31d8-1f41-39e" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="92ff-31d8-1f41-39e" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
             <entryLink import="true" name="Mechanical suit" hidden="true" id="c3c1-e495-4749-4322" type="selectionEntry" targetId="7b1-4b5e-5f87-b08d" sortIndex="5">
               <modifiers>
                 <modifier type="set" value="175" field="points"/>
@@ -117,7 +117,7 @@ They may never hire Elves of any sort!</description>
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="d5ca-8cb0-7fff-18ea" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry" sortIndex="2"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="700e-e816-3bc6-4b4f" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry" sortIndex="1"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="fa84-d20f-4d19-b7c8" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="fa84-d20f-4d19-b7c8" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
@@ -151,7 +151,7 @@ They may never hire Elves of any sort!</description>
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="1fd1-f692-336d-fb3c" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="dde4-aef2-a012-792c" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="dde4-aef2-a012-792c" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="f51f-8dd1-73aa-1eff" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="2"/>
             <entryLink import="true" name="Helmet" hidden="false" id="36f5-67f2-1409-8c77" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2" sortIndex="3"/>
           </entryLinks>
@@ -399,8 +399,7 @@ Clouds of black gas are slowly emitted until with an almighty belch, a wave of 
 
 
 The spell has a range of 8’’, hitting all models in its path on a D6 score of 4+. Any model hit suffers a S4 hit, roll to wound as normal.
-No armor saves allowed.
-</characteristic>
+No armor saves allowed.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -513,8 +512,7 @@ It can never be removed.</description>
 Attempts to parry its strikes are futile.
 
 
-A model attacked by a steel whip may not make parries with swords or bucklers.
-</description>
+A model attacked by a steel whip may not make parries with swords or bucklers.</description>
         </rule>
         <rule name="Whipcrack" id="82f8-2790-3445-2c18" hidden="false">
           <description>When the wielder charges they gain +1A for that turn.
@@ -526,8 +524,7 @@ This additional attack will ‘strike first’.
 If the wielder is simultaneously charged by two or more opponents they will still only receive a total of +1A.
 
 
-If the wielder is using two whips at the same time then they get +1A for the additional hand weapon, but only the first whip gets the whipcrack +1A.
-</description>
+If the wielder is using two whips at the same time then they get +1A for the additional hand weapon, but only the first whip gets the whipcrack +1A.</description>
         </rule>
       </rules>
     </selectionEntry>
@@ -2152,7 +2149,11 @@ Re-roll all results of ‘The lad’s got talent’ for them.</description>
         <categoryLink name="Stash" hidden="false" id="755d-8d4f-1e6a-bf78" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="9d9c-16a7-2ea6-8c6" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="9d9c-16a7-2ea6-8c6" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry" page="0">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="5280-8994-f8d6-5bb2" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="3bbd-8884-567-7413" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2301,6 +2302,39 @@ Captives     Hashut’s Reward
           </conditions>
         </modifier>
       </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="8ff1-9c6b-5839-0305">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="9065-0424-6643-8983" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="22a4-79ea-072e-f8f4-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="22a4-79ea-072e-f8f4-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Armor" id="43d1-9348-fe18-5606" hidden="false">
+          <description>Chaos Dwarfs never suffer movement penalties for wearing armor.</description>
+        </rule>
+        <rule name="Hard Head" id="f83a-da78-1370-bf45" hidden="false">
+          <description>Chaos Dwarfs ignore the special rules for clubs, maces, etc. They too are not easy to knock out!</description>
+        </rule>
+        <rule name="Hard to Kill" id="1a0e-803d-7524-bdc9" hidden="false">
+          <description>Like their uncorrupted brethren, Chaos Dwarfs are tough, resilient individuals who can only be taken out of action on a roll of 6 instead of 5-6 when rolling on the Injury chart.
+
+
+Treat a roll of 1-2 as knocked down, 3-5 as stunned, and 6 as out of action.</description>
+        </rule>
+        <rule name="Hired Swords" id="cc83-0d82-01f3-c840" hidden="false">
+          <description>A Chaos Dwarf warband may hire the following Hired Swords: Ogre Bodyguard, Pit Fighter, Warlock, Imperial Assassin, and Hobgoblin Scout.
+
+
+They may hire any Hired Sword described as all may hire, or allowed by Orc warbands and Chaos warbands.
+They may never hire Elves of any sort!</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="a326-f4ef-26b3-87a7" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Black Orcs.cat
+++ b/Black Orcs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="a831-b626-c36f-258b" name="Black Orcs (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="a831-b626-c36f-258b" name="Black Orcs (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="5ad9-1a6a-43ce-64a8" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -1276,7 +1276,11 @@ This is a single attack that automatically hits with a Strength of 5 and ignor
         <categoryLink name="Stash" hidden="false" id="8452-f227-5430-e067" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="d253-a649-1c06-bba3" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="d253-a649-1c06-bba3" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="f3d5-05d9-dba6-a823" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="c61d-3d1c-220c-6325" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -1284,6 +1288,31 @@ This is a single attack that automatically hits with a Strength of 5 and ignor
         <cost name="pts" id="2b44-a21d-a024-f6bd" hidden="false" typeId="points" value="0"/>
         <cost name="Warband Rating" id="0718-f75d-14db-0398" hidden="false" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="025e-61d4-1758-af62" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="72d1-0ea7-b67e-23ce" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="3990-9d4b-42e1-6e8c-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="3990-9d4b-42e1-6e8c-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Da Boss is Dead!" id="e1cf-9600-7e44-ba2a" hidden="false">
+          <description>If the Boss should be killed a Black Orc will always assume leadership of the warband before any other type, irrespective of relative experience.
+
+
+The replacement will automatically acquire the &quot;Oi Behave!&quot; skill.</description>
+        </rule>
+        <rule name="Let the goons do the work" id="bb5c-35b2-f28e-ef84" hidden="false">
+          <description>Black Orcs rely on themselves to do the killing and do not ride mounts of any kind.
+Only normal Orcs may ride a boar or other such mount.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="a2a2-1ff3-4a0a-2d57" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+        <infoLink name="Animosity" id="7a4d-5970-8dbc-c80e" hidden="false" type="rule" targetId="c214-2ad0-8f27-7328"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>
@@ -1413,8 +1442,8 @@ Any knocked down results which the Orc causes in hand-to-hand count as stunned
         <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="cba8-27ce-c6b0-1f66" targetId="74fb-cc90-1361-df26"/>
         <entryLink import="true" name="Buckler" hidden="false" type="selectionEntry" id="f89e-ba4a-e9ee-4a78" targetId="0871-44c2-f0f0-c27a"/>
         <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="c158-70a0-9dcf-ad5f" targetId="d0e5-ca89-5f0d-f5d2"/>
-        <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="c75d-cbeb-8399-bea" targetId="3d2a-426a-c350-2a03"/>
-        <entryLink import="true" name="Heavy Armor" hidden="false" type="selectionEntry" id="784c-9c6b-606c-bb52" targetId="4e34-bbc5-c7ef-6bd6"/>
+        <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="c75d-cbeb-8399-bea" targetId="3d2a-426a-c350-2a03"/>
+        <entryLink import="true" name="Heavy Armour" hidden="false" type="selectionEntry" id="784c-9c6b-606c-bb52" targetId="4e34-bbc5-c7ef-6bd6"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="d581-6e93-5202-a0cc" name="Hand-to-hand Weapons" hidden="false" collective="false" import="true">
@@ -1477,7 +1506,7 @@ Any knocked down results which the Orc causes in hand-to-hand count as stunned
         </entryLink>
         <entryLink import="true" name="Armor" hidden="false" type="selectionEntryGroup" id="e222-ce7b-def-60e2" targetId="433e-d45f-e58d-ee83">
           <entryLinks>
-            <entryLink import="true" name="Heavy Armor" hidden="false" type="selectionEntry" id="aa95-e613-d558-ab8" targetId="4e34-bbc5-c7ef-6bd6"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" type="selectionEntry" id="aa95-e613-d558-ab8" targetId="4e34-bbc5-c7ef-6bd6"/>
           </entryLinks>
           <modifiers>
             <modifier type="set" value="true" field="hidden">
@@ -1510,7 +1539,7 @@ Any knocked down results which the Orc causes in hand-to-hand count as stunned
       <entryLinks>
         <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="a558-e6cd-1e6f-fc22" targetId="74fb-cc90-1361-df26"/>
         <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="c87c-a5b2-8efa-6217" targetId="d0e5-ca89-5f0d-f5d2"/>
-        <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="734a-4180-b898-403b" targetId="3d2a-426a-c350-2a03"/>
+        <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="734a-4180-b898-403b" targetId="3d2a-426a-c350-2a03"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="4614-5b52-1b9a-2818" name="Skills" hidden="false" collective="false" import="true">

--- a/Bretonnian Knights.cat
+++ b/Bretonnian Knights.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="4ffc-66b0-fbc6-5a24" name="Bretonnian Knights (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="4ffc-66b0-fbc6-5a24" name="Bretonnian Knights (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="7d32-487d-bc16-1db1" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -36,12 +36,12 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" type="selectionEntry" id="4b9-fdf8-84dd-3113" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" type="selectionEntry" id="fb63-22d7-1cc4-ff04" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" type="selectionEntry" id="4cec-1af6-13a5-29e4" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" type="selectionEntry" id="4cec-1af6-13a5-29e4" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="5def-eac6-eeda-7cc7" targetId="34fd-d6a3-50ee-ee06" />
+            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="5def-eac6-eeda-7cc7" targetId="34fd-d6a3-50ee-ee06"/>
             <entryLink import="true" name="Axe" hidden="false" type="selectionEntry" id="b0ba-11ef-808e-3250" targetId="5d01-06b9-3a86-73c9"/>
             <entryLink import="true" name="Double Handed Weapon" hidden="false" type="selectionEntry" id="c9ae-26b4-b2cd-bf00" targetId="a0a1-b311-e3aa-6c3b"/>
             <entryLink import="true" name="Morning Star" hidden="false" type="selectionEntry" id="d1e4-34bc-5ff7-a80a" targetId="d5f3-1906-da91-4e8f"/>
@@ -64,8 +64,8 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="c897-77c2-58af-4587">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="466e-a6ed-e998-d4b5" targetId="3d2a-426a-c350-2a03"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" type="selectionEntry" id="d394-fbf9-8e11-945b" targetId="4e34-bbc5-c7ef-6bd6"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="466e-a6ed-e998-d4b5" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" type="selectionEntry" id="d394-fbf9-8e11-945b" targetId="4e34-bbc5-c7ef-6bd6"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="2fa4-893b-c61d-ec4e" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="8760-518-7a4-a259" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Warhorse" hidden="false" type="selectionEntry" id="7fb2-14f7-7311-af1a" targetId="7863-e620-5c6e-7eee"/>
@@ -80,7 +80,7 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" type="selectionEntry" id="e17b-9488-4024-7444" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" type="selectionEntry" id="697d-86eb-9722-e7f9" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" type="selectionEntry" id="9ddd-ba89-2689-a837" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" type="selectionEntry" id="9ddd-ba89-2689-a837" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -95,7 +95,7 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="3c5c-107f-a288-2b6f">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="1e88-6c6f-9b3e-e3e7" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="1e88-6c6f-9b3e-e3e7" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="244f-f307-1017-bafc" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="56ac-8ec6-be7c-3a0" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" type="selectionEntry" id="894d-1447-cc8-6c27" targetId="0871-44c2-f0f0-c27a"/>
@@ -119,12 +119,12 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" type="selectionEntry" id="e851-30c0-1e9c-52a2" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" type="selectionEntry" id="fd6b-8542-1277-9f1a" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" type="selectionEntry" id="a187-4524-eac0-d2b7" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" type="selectionEntry" id="a187-4524-eac0-d2b7" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="ea88-dc7-9478-5be8" targetId="34fd-d6a3-50ee-ee06" />
+            <entryLink import="true" name="Sword" hidden="false" type="selectionEntry" id="ea88-dc7-9478-5be8" targetId="34fd-d6a3-50ee-ee06"/>
             <entryLink import="true" name="Double Handed Weapon" hidden="false" type="selectionEntry" id="90d-3b9b-5a85-a002" targetId="a0a1-b311-e3aa-6c3b"/>
             <entryLink import="true" name="Spear" hidden="false" type="selectionEntry" id="3983-6285-45af-d2ea" targetId="005e-e397-8108-f198"/>
             <entryLink import="true" name="Axe" hidden="false" type="selectionEntry" id="dc03-90a8-d175-a98e" targetId="5d01-06b9-3a86-73c9"/>
@@ -143,7 +143,7 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="10ea-42e3-6f1f-25f7">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="79e1-1efc-a1d9-fe55" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="79e1-1efc-a1d9-fe55" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="22af-954e-9788-db32" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="f756-4768-63d2-c586" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
@@ -176,7 +176,7 @@ If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights an
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="1a61-3ecd-3e4a-d1f6">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="592b-f3ef-1a53-5e9c" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="592b-f3ef-1a53-5e9c" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="fa12-5f5b-bab0-b88e" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -1176,7 +1176,7 @@ He will never panic and break from combat and so does not have to pass a Leade
         <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Stash" hidden="false" id="65be-ab2e-83e9-18e4" collective="false">
+    <selectionEntry type="upgrade" import="true" name="Stash" hidden="false" id="65be-ab2e-83e9-18e4" collective="false" page="0">
       <constraints>
         <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cdb2-f4da-df98-7821" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9d85-ab23-048b-33b5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
@@ -1185,7 +1185,11 @@ He will never panic and break from combat and so does not have to pass a Leade
         <categoryLink name="Stash" hidden="false" id="fd96-0f06-a088-550b" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="730a-2de1-017c-a997" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="730a-2de1-017c-a997" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="0823-2adf-aeaa-123f" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="8866-b0ba-b7e4-b2dc" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -1193,6 +1197,44 @@ He will never panic and break from combat and so does not have to pass a Leade
         <cost name="pts" id="de11-9c58-9b21-0d9e" hidden="false" typeId="points" value="0"/>
         <cost name="Warband Rating" id="339b-1569-9e96-1c71" hidden="false" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="b540-b69b-580d-948c" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="cbc9-fb6e-a215-1e43" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="1ade-2323-8682-2599-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="1ade-2323-8682-2599-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Blessing of the Lake" id="a92f-9cca-a91c-0d0a" hidden="false">
+          <description>Before heading into battle Bretonnian Knights kneel and pray to the Lady of the Lake , avowing to fight to the death for honour and justice.
+
+
+Before playing a game of Mordheim make a Leadership test against the Leadership characteristic of the warbands leader.
+
+
+If the test is successful the Lady of the Lake has bestowed her blessing on the warband.
+
+
+The blessing takes the form of a powerful curse upon the enemies of chivalry; and in particular upon those that make use of the foul and dishonourable weapons of mass destruction.
+
+
+Any model in the opposing warband who wishes to fire a black powder weapon must roll a D6 and score 4 + to overcome the curse, otherwise they may not fire the weapon.
+
+
+The opposing player must test each time they wish to fire such a weapon.
+
+
+Models armed with other shooting weapons, such as bows and crossbows, do not have to test unless they dare raise their weapons against the gallant Knights of Bretonnia.
+
+
+If any enemy model wishes to shoot at a Bretonnian Knight (Questing Knights and Errants only), then they must first roll a 4+ on a D6 to overcome the curse.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="7e3f-df0a-8e82-df6a" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Carnival_of_Chaos.cat
+++ b/Carnival_of_Chaos.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3ca8-2429-2fa9-659e" name="Carnival of Chaos (1a)" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="3ca8-2429-2fa9-659e" name="Carnival of Chaos (1a)" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="a8de-6c73-092a-998b" name="Carnival Master" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -1300,6 +1300,23 @@ The Plague Cart automatically passes any Leadership-based test it is required to
           </modifiers>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="23e3-c862-9c44-78d7" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="9df2-54c3-1663-4afb" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="28a0-4594-a1f5-64e2-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="28a0-4594-a1f5-64e2-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Dangerous to Know" id="bfc5-92f5-d0cd-fe2c" hidden="false">
+          <description>Because of its rather diseased nature a Carnival of Chaos warband would find it very hard to keep any Hired Swords alive! Therefore, a Carnival of Chaos may never hire any type of Hired Sword.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="8f23-3438-1296-640b" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Dark_Elves.cat
+++ b/Dark_Elves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="306dc1be-876f-4f6e-a4a8-4465e1309b7f" name="Dark Elves (1b)" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="306dc1be-876f-4f6e-a4a8-4465e1309b7f" name="Dark Elves (1b)" revision="15" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83acbe09-ec66-c45c-0f5b-1a9e0017016e" name="High Born" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -1333,6 +1333,32 @@
         <cost name="pts" typeId="points" value="30"/>
         <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="8ede-5484-7979-08df" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="701c-97f3-af96-1b72" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="3319-693c-5737-c8b8-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="3319-693c-5737-c8b8-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Black Powder Weapons" id="757d-617b-1c6a-ab47" hidden="false">
+          <description>Dark Elves may never use black powder weapons as they ﬁnd them too crude, noisy and unreliable.</description>
+        </rule>
+        <rule name="Excellent Sight" id="34e0-d8e6-fa74-6b32" hidden="false">
+          <description>Elves can spot Hidden enemies from twice as far away as other warriors (i.e. twice their Initiative in inches).</description>
+        </rule>
+        <rule name="Kindred Hatred" id="3f67-e91c-dd6c-c226" hidden="false">
+          <description>The Dark Elves have been ﬁghting the High Elves for many centuries.
+The wars between these two races have been very long and bloody affairs.
+Dark Elves Hate any High Elf warriors including High Elf Hired Swords.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP Adancement" id="a951-2e38-b698-b6bd" hidden="false" targetId="bd2100cc-65f9-2311-e4b9-d0e6830884c3" type="rule"/>
+        <infoLink name="Hatred" id="4a91-2b07-816f-a380" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Dwarf Rangers.cat
+++ b/Dwarf Rangers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="1df8-a2ec-8d5c-c7b" name="Dwarf Rangers (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="7" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="1df8-a2ec-8d5c-c7b" name="Dwarf Rangers (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="8" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <rules>
     <rule name="Don’t Trust ‘Em" hidden="false" id="c420-9cfa-bfde-368a">
       <description>While Ranger Warbands are free to ally with other Dwarf warbands in multi-player games, their point of view is so different that they do not trust them fully.
@@ -31,7 +31,7 @@ Later purchases of Gromril weapons are done using the Price Charts in the Mordh
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" type="selectionEntry" id="d040-797a-8497-943d" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" type="selectionEntry" id="8786-cd1d-6cfd-92e2" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" type="selectionEntry" id="4801-7df7-4eda-2429" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" type="selectionEntry" id="4801-7df7-4eda-2429" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace, Hammer" field="name"/>
               </modifiers>
@@ -72,8 +72,8 @@ Later purchases of Gromril weapons are done using the Price Charts in the Mordh
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="337d-3438-261d-a99a">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="bc4f-e83-34a5-91c1" targetId="3d2a-426a-c350-2a03"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" type="selectionEntry" id="f70f-d546-cfa-34ba" targetId="4e34-bbc5-c7ef-6bd6"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="bc4f-e83-34a5-91c1" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" type="selectionEntry" id="f70f-d546-cfa-34ba" targetId="4e34-bbc5-c7ef-6bd6"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="4c71-f0ae-4816-4332" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="b733-eb64-ee58-3680" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
@@ -94,7 +94,7 @@ Later purchases of Gromril weapons are done using the Price Charts in the Mordh
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" type="selectionEntry" id="f23e-fc94-d5e2-9204" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" type="selectionEntry" id="b1d3-3d4-7a51-be34" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" type="selectionEntry" id="50d2-bdc6-2dc0-fdcf" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" type="selectionEntry" id="50d2-bdc6-2dc0-fdcf" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace, Hammer" field="name"/>
               </modifiers>
@@ -123,8 +123,8 @@ Later purchases of Gromril weapons are done using the Price Charts in the Mordh
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="a789-83f8-6600-f498">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="926a-36b9-ae54-f23f" targetId="3d2a-426a-c350-2a03"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" type="selectionEntry" id="60f5-4828-3bcb-8d5b" targetId="4e34-bbc5-c7ef-6bd6"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="926a-36b9-ae54-f23f" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" type="selectionEntry" id="60f5-4828-3bcb-8d5b" targetId="4e34-bbc5-c7ef-6bd6"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="555c-8074-9d14-4dcd" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" type="selectionEntry" id="5a1a-a7b0-8e0f-fbda" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Gromril Armour" hidden="false" type="selectionEntry" id="3b5c-88c7-75-4b77" targetId="4c6d-eb92-53a7-a6d3">
@@ -3245,7 +3245,11 @@ Remember that you can never reroll a reroll, so the result of this second roll 
         <categoryLink name="Stash" hidden="false" id="1fd0-128d-bf93-d21e" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="9e33-d702-6f7-422f" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="9e33-d702-6f7-422f" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="a22b-ab24-c787-51cd" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="f84-8be6-b661-8f32" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -3253,6 +3257,42 @@ Remember that you can never reroll a reroll, so the result of this second roll 
         <cost name="pts" id="8517-8812-cd77-d2b0" hidden="false" typeId="points" value="0"/>
         <cost name="Warband Rating" id="5acd-8079-9a47-7749" hidden="false" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="0282-6e4b-e6d6-6309" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3cb3-0094-e80e-4f17" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="9785-16d5-7b4b-6fd6-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="9785-16d5-7b4b-6fd6-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Don’t Trust ‘Em" id="aeb7-32ae-021c-141e" hidden="false">
+          <description>While Ranger Warbands are free to ally with other Dwarf warbands in multi-player games, their point of view is so different that they do not trust them fully.
+
+
+Members of a Dwarf Rangers warband are never considered ‘friendly models’ to other dwarfs and vice versa.
+
+
+This means that members of one warband WILL stop members of the other from Marching, they won’t keep each other from taking All Alone tests, etc.
+
+
+They don’t count as enemy models and may split any treasure found at the end of the game as normal, but the two bands are not friends, make no mistake!</description>
+        </rule>
+        <rule name="Starting Gromril weapons" id="0135-474f-db6d-2ff7" hidden="false">
+          <description>Any weapon a Dwarf may normally purchase may be purchased as a Gromril weapon instead.
+This multiplies the cost of the weapon by three.
+
+
+Note that this price is only for a starting warband, as it represents the Dwarfs outfitting themselves at their own stronghold.
+
+
+Later purchases of Gromril weapons are done using the Price Charts in the Mordheim rulebook.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="b836-7557-6931-c1fb" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Dwarven_Tresure_Hunters.cat
+++ b/Dwarven_Tresure_Hunters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8315579e-b80d-5ed1-7a51-d85cdf59c06b" name="Dwarf Treasure Hunters (1a)" revision="22" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="8315579e-b80d-5ed1-7a51-d85cdf59c06b" name="Dwarf Treasure Hunters (1a)" revision="23" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="2d1dabde-1182-a9db-6186-35bff94b4a69" name="Beardlings" page="0" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -154,7 +154,11 @@
                 <entryLink import="true" name="Shield" hidden="false" id="5415-781f-f00f-954a" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="4"/>
                 <entryLink import="true" name="Light Armour" hidden="false" id="e6e5-cd95-df3b-6eeb" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
                 <entryLink import="true" name="Heavy Armour" hidden="false" id="e641-335e-2aa9-e607" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
-                <entryLink import="true" name="Gromril Armour" hidden="false" id="8e31-9395-04dc-eebe" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3" sortIndex="3"/>
+                <entryLink import="true" name="Gromril Armour" hidden="false" id="8e31-9395-04dc-eebe" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3" sortIndex="3">
+                  <costs>
+                    <cost name=" gc" typeId="points" value="75"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup name="Hand-to-hand Weapons" id="c85b-3d57-afaf-03e9" hidden="false" sortIndex="1">
@@ -434,9 +438,9 @@
                 <entryLink import="true" name="Gromril Armour" hidden="false" id="bc88-27fb-3d7e-6d29" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3" sortIndex="3"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup name="Hand-to-hand Weapons" id="6ad5-8208-76d0-18e1" hidden="false" sortIndex="1">
+            <selectionEntryGroup name="Hand-to-hand Weapons" id="6ad5-8208-76d0-18e1" hidden="false" sortIndex="1" collapsible="true">
               <entryLinks>
-                <entryLink import="true" name="Mace" hidden="false" id="e586-3cf4-fd53-1077" collective="false" targetId="2cbb-013b-3ebf-0459" type="selectionEntry" sortIndex="3"/>
+                <entryLink import="true" name="Mace" hidden="false" id="e586-3cf4-fd53-1077" targetId="2cbb-013b-3ebf-0459" type="selectionEntry" sortIndex="3"/>
                 <entryLink import="true" name="Dagger" hidden="false" id="1044-2924-01f7-45ee" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry" sortIndex="2"/>
                 <entryLink import="true" name="Free Dagger" hidden="false" id="98bb-b11d-a63d-02e4" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry" sortIndex="1"/>
                 <entryLink import="true" name="Sword" hidden="false" id="ce46-d9c1-caa3-439f" collective="false" targetId="34fd-d6a3-50ee-ee06" type="selectionEntry" sortIndex="6"/>
@@ -457,6 +461,21 @@
                   </conditions>
                 </modifier>
               </modifiers>
+              <profiles>
+                <profile name="Hand-to-hand Weapons" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model" hidden="false" id="a62c-bd5f-29af-9985">
+                  <characteristics>
+                    <characteristic name="M" typeId="2a0bcc4c-8266-418f-13d6-a6b44def5e92"/>
+                    <characteristic name="WS" typeId="d5aca8ba-0204-b324-b976-c2b536e09924"/>
+                    <characteristic name="BS" typeId="5b4d181b-23ae-5ed7-9262-c1d2f79246a8"/>
+                    <characteristic name="S" typeId="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9"/>
+                    <characteristic name="T" typeId="54f4796b-dedb-c296-8b1a-ff7f8043293a"/>
+                    <characteristic name="W" typeId="3172c8dc-ebe4-0c40-72ab-8fd0076b9442"/>
+                    <characteristic name="I" typeId="a6fd52b0-be0a-655e-6314-87b392c9c90e"/>
+                    <characteristic name="A" typeId="bf393c37-9d10-fc85-c147-62b1c01a89fe"/>
+                    <characteristic name="LD" typeId="e234eaea-a02a-2fb7-3e1f-605392aabb89"/>
+                  </characteristics>
+                </profile>
+              </profiles>
             </selectionEntryGroup>
             <selectionEntryGroup name="Missile Weapons" id="dbba-54db-86d5-623f" hidden="false" sortIndex="2">
               <entryLinks>
@@ -465,6 +484,9 @@
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="56af-7a2a-39a1-14b2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
               </constraints>
+              <modifiers>
+                <modifier type="decrement" value="1" field="56af-7a2a-39a1-14b2"/>
+              </modifiers>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <constraints>
@@ -941,6 +963,9 @@
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c5d6-28c5-454b-5a32" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
               </constraints>
+              <modifiers>
+                <modifier type="decrement" value="0" field="c5d6-28c5-454b-5a32"/>
+              </modifiers>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <constraints>
@@ -1428,7 +1453,11 @@
       </profiles>
       <rules>
         <rule id="3b3019fc-ab69-2ae2-8d8d-b253b1516358" name="Deathwish" page="0" hidden="false">
-          <description>Troll Slayers seek an honourable death in combat. They are completely immune to all psychology and never need to test if fighting alone</description>
+          <description>Troll Slayers seek an honourable death in combat. They are completely immune to all psychology and never need to test if fighting alone
+</description>
+        </rule>
+        <rule name="Equipment Restriction" id="38f2-7247-2bfe-63a0" hidden="false">
+          <description>Slayers may never carry or use missile weapons or any form of armour.</description>
         </rule>
       </rules>
       <categoryLinks>
@@ -1461,7 +1490,28 @@
                 <entryLink import="true" name="Shield" hidden="false" id="b3aa-c4c6-ec78-596e" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="4"/>
                 <entryLink import="true" name="Light Armour" hidden="false" id="03e7-d036-3d08-eccd" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
                 <entryLink import="true" name="Heavy Armour" hidden="false" id="86f4-e10a-5b82-1e8b" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
-                <entryLink import="true" name="Gromril Armour" hidden="false" id="8989-ce25-2045-6665" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3" sortIndex="3"/>
+                <entryLink import="true" name="Gromril Armour" hidden="false" id="8989-ce25-2045-6665" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3" sortIndex="3">
+                  <costs>
+                    <cost name=" gc" typeId="points" value="75"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Armour" id="d9cd-1ecf-cab5-aaa6" hidden="false" sortIndex="3">
+              <entryLinks>
+                <entryLink import="true" name="Helmet" hidden="false" id="62e5-9662-c8e2-441b" collective="false" targetId="d0e5-ca89-5f0d-f5d2" type="selectionEntry" sortIndex="5">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5481-cd0c-806e-a6e4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Shield" hidden="false" id="b3aa-c4c6-ec78-596e" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="4"/>
+                <entryLink import="true" name="Light Armour" hidden="false" id="03e7-d036-3d08-eccd" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+                <entryLink import="true" name="Heavy Armour" hidden="false" id="86f4-e10a-5b82-1e8b" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
+                <entryLink import="true" name="Gromril Armour" hidden="false" id="8989-ce25-2045-6665" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3" sortIndex="3">
+                  <costs>
+                    <cost name=" gc" typeId="points" value="75"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup name="Hand-to-hand Weapons" id="af20-2147-e69c-7882" hidden="false" sortIndex="1">
@@ -1567,6 +1617,39 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="075f-adcf-7fd0-5c41" page="0">
+      <categoryLinks>
+        <categoryLink targetId="4852-c4cb-82b0-b7fa" id="b839-ae6d-8b05-be44" primary="true" name="Configuration"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="9ada-cc39-d78d-f23c-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="9ada-cc39-d78d-f23c-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Armour Use" id="f5d2-69d6-58e2-fb76" hidden="false" page="0">
+          <description>Dwarfs never suffer movement penalties for wearing armour.</description>
+        </rule>
+        <rule name="Grudgebearers" id="e1c4-6a34-a230-df47" hidden="false" page="0">
+          <description>Dwarfs hold an ancient grudge against Elves from the days when the two races fought for supremacy in the Old World. A Dwarf warband may never include any kind of Elven Hired Sword or Dramatis Personae.</description>
+        </rule>
+        <rule name="Hard Head" id="0327-afbe-2027-434d" hidden="false" page="0">
+          <description>Dwarfs ignore the special rules for maces, clubs,etc. used against them.</description>
+        </rule>
+        <rule name="Hard to Kill" id="27d7-0654-ad2b-78cb" hidden="false" page="0">
+          <description>Dwarfs are tough, resilient individuals who can only be taken out of action on a roll of 6 instead of 5-6 when rolling on the Injury chart. Treat a roll of 1-2 as knocked down, 3-5 as stunned, and 6 as out of action.</description>
+        </rule>
+        <rule name="Hate Orcs and Goblins" id="7a56-e9a4-3ee1-518c" hidden="false" page="0">
+          <description>All Dwarfs hate Orcs and Goblins</description>
+        </rule>
+        <rule name="Incomparable Miners" id="3235-282d-a280-2356" hidden="false" page="0">
+          <description>Dwarfs spend much of their lives underground searching for precious minerals, and they are the best in the world at this kind of work. In the city of Mordheim they apply similar skills to the search for wyrdstone. When checking for wyrdstone at the end of a game, add +1 to the number of pieces found for a Dwarf warband.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="d5ea-23d1-fdae-7583" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+        <infoLink name="Hatred" id="9e78-1b0a-4a78-252f" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <rules>
     <rule id="61761c75-b111-0d47-7fca-d1a50f33ef93" name="Hard Head" page="0" hidden="false">
@@ -1590,7 +1673,7 @@
   </rules>
   <infoLinks>
     <infoLink id="f98676e7-07fd-7cea-03c3-483ac99b0435" hidden="false" targetId="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" type="rule" name="Hatred"/>
-    <infoLink id="21dc314b-01d7-9a0e-3606-fc4b640d9271" hidden="false" targetId="dc466bee-0dd9-eaa2-db68-d16f58af2521" type="rule" name="EXP Advancement"/>
+    <infoLink id="21dc314b-01d7-9a0e-3606-fc4b640d9271" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule" name="EXP advancement"/>
   </infoLinks>
   <sharedSelectionEntries>
     <selectionEntry id="8acf5ee1-3430-be22-ec94-15b12e15e497" name="+1 A" page="0" hidden="false" collective="true" import="true" type="upgrade">

--- a/Forest Goblins.cat
+++ b/Forest Goblins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="c07d-10eb-1eaf-ab77" name="Forest Goblins (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="c07d-10eb-1eaf-ab77" name="Forest Goblins (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="2916-c073-fa3f-e13e" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -166,7 +166,7 @@ Note even if the rider has the Running Dismount skill, the maximum diving charg
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="34b8-cf53-f8a-2978">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" type="selectionEntry" id="f1a2-1d90-5b79-c26b" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" type="selectionEntry" id="f1a2-1d90-5b79-c26b" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="e2bc-35ab-9c1b-45e9" targetId="74fb-cc90-1361-df26"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -418,7 +418,7 @@ The effects last until the Shaman takes a wound.</characteristic>
         <infoLink id="3177-dd11-286b-1e3d" name="Leader" hidden="false" targetId="8712-d0f2-fe64-07bd" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4b13-db19-e4cc-c13c" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="4b13-db19-e4cc-c13c" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="aae6-594b-8ccb-9e22" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -587,7 +587,7 @@ The effects last until the Shaman takes a wound.</characteristic>
         <infoLink id="d444-4aca-a763-94a1" name="Goblin max" hidden="false" targetId="de0f-ab0b-13a4-cefc" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2ace-ab-cd50-cd47" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="2ace-ab-cd50-cd47" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="10-5099-2ce6-cae4" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -756,7 +756,7 @@ The effects last until the Shaman takes a wound.</characteristic>
         <infoLink name="Animosity" hidden="false" type="rule" id="906-f5b2-6cd7-f0f7" targetId="c214-2ad0-8f27-7328"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="35d7-a014-6e1b-5bb" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="35d7-a014-6e1b-5bb" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="229-bcb5-3ddf-d279" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -930,7 +930,7 @@ The effects last until the Shaman takes a wound.</characteristic>
         <infoLink name="Animosity" hidden="false" type="rule" id="3e3f-9125-2e3f-7206" targetId="c214-2ad0-8f27-7328"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="96e4-2a67-cf96-d697" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="96e4-2a67-cf96-d697" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1a2a-7d9d-c3ed-59a1" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1090,7 +1090,7 @@ The effects last until the Shaman takes a wound.</characteristic>
         <infoLink name="Frenzy" hidden="false" type="rule" id="143f-e266-7983-138c" targetId="ce28-23a1-7b2a-7e6c"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a17b-4974-4cfc-448e" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="a17b-4974-4cfc-448e" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c20a-7795-d762-4439" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1264,7 +1264,7 @@ In addition, if they begin their turn within charge range of an enemy, they ar
         <infoLink name="Animosity" hidden="false" type="rule" id="cfcd-a043-1c93-3305" targetId="c214-2ad0-8f27-7328"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5ef4-803e-3475-bdc2" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="5ef4-803e-3475-bdc2" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d2bb-887f-c565-61ed" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1436,7 +1436,7 @@ This may not be combined with Quick Shot if they should be promoted to hero st
         <infoLink name="Animals" hidden="false" type="rule" id="c2ea-e835-e14c-126b" targetId="daaa-38f1-8c4c-3140"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="19de-811e-9a5-2bb3" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="19de-811e-9a5-2bb3" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20"/>
@@ -1472,6 +1472,24 @@ In close combat, the opponent may choose which to hit.
 The Gigantic Spider no longer has to check for stupidity if it is being ridden, as the Chieftain is directing its actions.</description>
         </rule>
       </rules>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="7cb4-647e-f1e9-5655" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3fd9-cae0-32e0-f2fd" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="8fd2-538f-c821-cc0d-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="8fd2-538f-c821-cc0d-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Natives" id="5ad7-3e44-b16a-4ccd" hidden="false">
+          <description>Used to poking through the underbrush, Forest Goblins suffer no movement penalties from moving through any wooded terrain.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="6589-00f2-f161-48d5" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+        <infoLink name="Animosity" id="b2bc-5e44-648d-cc50" hidden="false" type="rule" targetId="c214-2ad0-8f27-7328"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Gunnery School Of Nuln.cat
+++ b/Gunnery School Of Nuln.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9fda-1198-8b84-972e" name="Gunnery School Of Nuln (1b)" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="9fda-1198-8b84-972e" name="Gunnery School Of Nuln (1b)" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <comment>The province of Nuln is respected across the Empire as the home to the finest handguns and war machines, save for those constructed by the Dwarfs.
 This makes them a desired commodity for any Imperial army using cannonry and as such graduates from the Imperial Gunnery School are highly prized for their skills in training artillery on vulnerable targets with unerring accuracy and maintaining the war machines.
 Perhaps the most surprising fact is that the Imperial Gunnery School does not create new weapons of war.
@@ -142,7 +142,7 @@ Their abilities vary from undeveloped to talented, but they are always very well
         <infoLink id="5698-fbe4-c7a6-b841" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4cd9-d837-96d9-93c9" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="4cd9-d837-96d9-93c9" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="146f-78c4-c63b-274e" name="Serious Injury" hidden="false" collective="false" import="true" type="upgrade">
@@ -465,7 +465,7 @@ While there is an Instructor in the warband all Pistol weapons receive a +3” r
         <infoLink id="1e20-697e-b467-e234" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ecd5-5f53-3a21-943b" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="ecd5-5f53-3a21-943b" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="962c-3bda-4366-b965" name="Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -650,7 +650,7 @@ While there is an Instructor in the warband all Pistol weapons receive a +3” r
         <infoLink id="8cd3-8db5-bbe7-a3c3" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="94ac-b5bd-324d-a425" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="94ac-b5bd-324d-a425" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="64bb-dce3-4e36-4459" name="Serious Injury" hidden="false" collective="false" import="true" type="upgrade">
@@ -836,7 +836,7 @@ While there is an Instructor in the warband all Pistol weapons receive a +3” r
         <infoLink id="16ac-760d-f514-bbb5" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a56f-23a5-cf4e-8e6c" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="a56f-23a5-cf4e-8e6c" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="23da-ed90-7a60-1e64" name="Serious Injury" hidden="false" collective="false" import="true" type="upgrade">
@@ -1203,7 +1203,7 @@ A Marksman who becomes a Hero gains no further effect from taking the Hunter ski
         <infoLink id="276c-409e-7c0d-0ec3" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6034-b5d6-c3e9-a020" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="6034-b5d6-c3e9-a020" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="343c-40ac-c7de-8210" name="Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1391,7 +1391,7 @@ When using pistols in close combat, they may re-roll any missed to-hit rolls wit
         <infoLink id="7bcb-2b27-bc41-fe0a" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4ece-5e7c-60f3-b634" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="4ece-5e7c-60f3-b634" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b1e5-9261-84a7-4974" name="Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1464,7 +1464,7 @@ When using pistols in close combat, they may re-roll any missed to-hit rolls wit
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0266-0358-9b37-507b" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="764b-b45e-0d5c-3efc" name="New CategoryLink" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="764b-b45e-0d5c-3efc" name="Stash" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="ee2b-d0d9-2db6-4574" name="Wyrdstone" hidden="false" collective="false" import="true" type="upgrade">
@@ -1485,6 +1485,25 @@ When using pistols in close combat, they may re-roll any missed to-hit rolls wit
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="45b4-4137-1019-9dcb" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="830f-b04f-fa78-8089" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="b27b-b891-14b5-2e08-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="b27b-b891-14b5-2e08-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Impeccable Care" id="e245-6c98-80c0-8b09" hidden="false">
+          <description>Amongst one of the first things that the students are taught is to take proper care of their equipment and the right way to perform that maintenance. Once they have mastered this function, they learn to repair the same weapons should they become damaged and because of this they can buy such black powder weapons on the cheap and quickly return them to good working order. As a result they can buy these weapons at a fairly reduced price! They can ALWAYS use the reduced cost for black powder weapons listed in their starting Equipment List, and they gain an additional +2 on rare rolls to find any black powder weapons since people don’t mind selling broken guns!</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="746f-db71-0ced-1c70" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+        <infoLink name="Proud To A Fault!" id="af17-68e7-2415-8a78" hidden="false" targetId="nuln-proud-to-a-fault" type="rule"/>
+        <infoLink name="Properly Used" id="4ff5-1117-b138-eb85" hidden="false" targetId="nuln-properly-used" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>
@@ -2136,18 +2155,18 @@ When using pistols in close combat, they may re-roll any missed to-hit rolls wit
     </selectionEntryGroup>
     <selectionEntryGroup id="3401-49f9-24b2-d1f7" name="Gunnery School Equipment List" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="abfb-c331-00ea-2396" name="Gunnery School Equipment List (Armour)" hidden="false" collective="false" import="true" targetId="99f5-d53a-5edd-6a69" type="selectionEntryGroup"/>
+        <entryLink id="abfb-c331-00ea-2396" name="Armour" hidden="false" collective="false" import="true" targetId="99f5-d53a-5edd-6a69" type="selectionEntryGroup"/>
         <entryLink id="0f03-d35c-5af0-a314" name="Melee" hidden="false" collective="false" import="true" targetId="22b9-06dc-e9c7-161f" type="selectionEntryGroup"/>
         <entryLink id="181a-a315-0d1b-6a66" name="Miscellaneous" hidden="false" collective="false" import="true" targetId="df16-2297-d0f1-8e36" type="selectionEntryGroup"/>
-        <entryLink id="f6ad-f969-cb8e-2b18" name="Missile" hidden="false" collective="false" import="true" targetId="a631-8ebd-b27b-bdb2" type="selectionEntryGroup"/>
+        <entryLink id="f6ad-f969-cb8e-2b18" name="Ranged" hidden="false" collective="false" import="true" targetId="a631-8ebd-b27b-bdb2" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="00b7-59a2-6908-f08e" name="Marksmen Equipment List" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="719f-f704-6887-1f31" name="Marksmen Equipment List (Armour)" hidden="false" collective="false" import="true" targetId="97f2-3a43-8f5c-534e" type="selectionEntryGroup"/>
+        <entryLink id="719f-f704-6887-1f31" name="Armour" hidden="false" collective="false" import="true" targetId="97f2-3a43-8f5c-534e" type="selectionEntryGroup"/>
         <entryLink id="26f7-4b0d-75ae-0dc3" name="Melee" hidden="false" collective="false" import="true" targetId="ca3a-373c-3f4c-a66f" type="selectionEntryGroup"/>
         <entryLink id="3edc-15a1-db32-f133" name="Miscellaneous" hidden="false" collective="false" import="true" targetId="60d6-da0f-48db-d2ca" type="selectionEntryGroup"/>
-        <entryLink id="768b-8ce9-3e6b-623a" name="Missile" hidden="false" collective="false" import="true" targetId="033e-f818-e0eb-81a0" type="selectionEntryGroup"/>
+        <entryLink id="768b-8ce9-3e6b-623a" name="Ranged" hidden="false" collective="false" import="true" targetId="033e-f818-e0eb-81a0" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="74a2-012b-b556-e736" name="Characteristic Increases" hidden="false" collective="false" import="true">
@@ -2182,7 +2201,7 @@ When using pistols in close combat, they may re-roll any missed to-hit rolls wit
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4f36-f960-253e-5dae" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry">
+            <entryLink id="4f36-f960-253e-5dae" hidden="false" collective="false" import="true" targetId="bf7c1f26-0442-54db-cacc-44dc499dcebc" type="selectionEntry" name="-1 M">
               <modifiers>
                 <modifier type="set" field="5da5-ec71-c528-7c00" value="1"/>
               </modifiers>
@@ -2229,7 +2248,7 @@ When using pistols in close combat, they may re-roll any missed to-hit rolls wit
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="247c-1bad-2abc-39f7" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry">
+            <entryLink id="247c-1bad-2abc-39f7" hidden="false" collective="false" import="true" targetId="d4b94626-ea08-5302-d7a8-7783f7e1fdc8" type="selectionEntry" name="-1 T">
               <modifiers>
                 <modifier type="set" field="2c67-e413-6bf6-e238" value="1"/>
               </modifiers>
@@ -2277,7 +2296,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="108e-5b88-fbab-ee28" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry">
+            <entryLink id="108e-5b88-fbab-ee28" hidden="false" collective="false" import="true" targetId="ceb4c328-6b8b-79ef-05fe-d4858b4bb69f" type="selectionEntry" name="-1 I">
               <modifiers>
                 <modifier type="set" field="20ec-fcd6-f65c-267d" value="1"/>
               </modifiers>
@@ -2295,7 +2314,7 @@ must retire from the warband.</description>
             </rule>
           </rules>
           <entryLinks>
-            <entryLink id="4335-154b-73f5-d6eb" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry">
+            <entryLink id="4335-154b-73f5-d6eb" hidden="false" collective="false" import="true" targetId="abc4f440-9124-351f-831d-aaf5be4d3ae4" type="selectionEntry" name="-1 WS">
               <modifiers>
                 <modifier type="set" field="62f1-39a4-3caa-7864" value="1"/>
               </modifiers>
@@ -3213,7 +3232,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         </selectionEntry>
         <selectionEntry id="1018-1754-b429-8376" name="Double Barreled Duelling Pistol" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="b577-fa98-ce4c-006d" name="Double Barrelled Duelling Pistols" hidden="false" targetId="1047-f381-53ae-1453" type="profile"/>
+            <infoLink id="b577-fa98-ce4c-006d" name="Duelling Pistols" hidden="false" targetId="1047-f381-53ae-1453" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="35"/>
@@ -3222,7 +3241,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         </selectionEntry>
         <selectionEntry id="cdfe-e44a-5651-37eb" name="Double Barreled Duelling Pistol (Brace)" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="6089-6a70-800c-d0f8" name="Double Barrelled Duelling Pistols" hidden="false" targetId="1047-f381-53ae-1453" type="profile"/>
+            <infoLink id="6089-6a70-800c-d0f8" name="Duelling Pistols" hidden="false" targetId="1047-f381-53ae-1453" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="65"/>

--- a/High_Elf_Shadow_Warriors.cat
+++ b/High_Elf_Shadow_Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a808d69a-88e2-9484-b24a-181ea44917e5" name="Shadow Warriors (1b)" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="a808d69a-88e2-9484-b24a-181ea44917e5" name="Shadow Warriors (1b)" revision="14" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83acbe09-ec66-c45c-0f5b-1a9e0017016e" name="Shadow Master" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -1142,6 +1142,38 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="13d4-f43c-af1f-ecdf" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="a335-35a9-5037-5085" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="23c5-39d2-8761-4982-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="23c5-39d2-8761-4982-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Excellent Sight" id="6096-a283-4b83-d99c" hidden="false">
+          <description>All the Elves in a
+Shadow Warrior Warband can spot Hidden
+enemies from twice as far away as other
+warriors (i.e. twice their Initiative in inches).</description>
+        </rule>
+        <rule name="Hate Dark Elves" id="265c-c503-4f3f-104e" hidden="false">
+          <description>All warriors in a Shadow Warrior Warband (excluding any Hired Swords) have an unyielding Hatred for Dark Elves.</description>
+        </rule>
+        <rule name="Tolerant" id="7d6a-3480-8912-51be" hidden="false">
+          <description>A Shadow Warrior Warband may hire any Hired Sword that is not of a Chaotic or evil bent (so no Skaven,Possessed, Beastmen, Dark Elves, Undead,etc.). They also shun the company of anyone specialising in the use of poison (so no Assassins).</description>
+        </rule>
+        <rule name="Unforgiving" id="c1a6-1cec-1408-5047" hidden="false">
+          <description>a Shadow Warrior warband may never forge an alliance
+with any Warband of a Chaotic nature
+(Possessed, Skaven, Beastmen, Dark Elves,
+etc.).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP Adancement" id="bdc4-3ab9-295a-d5af" hidden="false" targetId="bd2100cc-65f9-2311-e4b9-d0e6830884c3" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Hochland Bandits.cat
+++ b/Hochland Bandits.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ff8e-be11-7016-5abc" name="Hochland Bandits (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ff8e-be11-7016-5abc" name="Hochland Bandits (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="3737-518b-3731-edba" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -3297,7 +3297,7 @@ Gutterscum do not gain experience.</description>
         <categoryLink name="Stash" hidden="false" id="4413-51bc-e7f6-4c75" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="cf30-b16c-1fc2-1c05" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="cf30-b16c-1fc2-1c05" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="3202-ccd3-cd37-7ba7" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="3801-d53b-ebb9-a2e0" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -3305,6 +3305,43 @@ Gutterscum do not gain experience.</description>
         <cost name="pts" hidden="false" id="791a-909d-67c8-ee5e" typeId="points" value="0"/>
         <cost name="Warband Rating" hidden="false" id="c87c-e48c-2c-2284" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="79b6-ea8b-9b00-7aa5" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="ad58-2c8e-1f6c-76ee" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="c16b-d26f-00cd-0b8d-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="c16b-d26f-00cd-0b8d-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Foragers" id="8e17-0561-47cf-20cc" hidden="false">
+          <description>Bandits are used to lean times, and know how to make their gold stretch.
+Because of this, they usually have fewer expenses between adventures.
+When determining Income for a Bandit warband, always use the next lower warband size category (a warband with 1-3 members still uses the first column however!).
+For example, a warband with 15 members finds 4 Treasures in the Exploration Phase.
+When they sell these Treasures, they use the 10-12 members column instead of the 13-15 members column, resulting in a gain of 5 gold pieces for the warband.</description>
+        </rule>
+        <rule name="Hired Swords" id="a196-1e38-1a48-2fad" hidden="false">
+          <description>Bandits have no compunction about hiring mercenaries, and may hire any Hired Swords allowed to a Human Mercenary warband.</description>
+        </rule>
+        <rule name="Know Who To Sell To" id="bb9e-9450-8732-1e25" hidden="false">
+          <description>Bandits are used to getting rid of stolen goods, and have built up contacts for doing so.
+When a Bandit warband sells equipment, they get half of any random element of the equipment cost, in addition to the normal half of the item&apos;s basic cost.</description>
+        </rule>
+        <rule name="Powder&apos;s Expensive!" id="fd92-48e7-38f3-5d54" hidden="false">
+          <description>Bandits are often too poor to purchase or upkeep expensive equipment like gunpowder weapons.
+
+
+The exception to this is Bandit heroes, who often see such extravagances as pistols as symbols of their status and higher wealth.
+
+
+The higher costs for black powder weapons in the equipment chart, and the fact that henchmen can&apos;t purchase them at all, reflect the extreme rarity of these types of weapons for Bandit warbands.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="2ea9-df57-f59a-80ea" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>
@@ -3401,7 +3438,7 @@ If an Enemy warrior is attempting to detect the bandit While he is Hidden, rol
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="8488-c598-435d-811c" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="8201-82eb-953d-40e9" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="e664-2b40-3e2-ec4b" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="e664-2b40-3e2-ec4b" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -3440,7 +3477,7 @@ If an Enemy warrior is attempting to detect the bandit While he is Hidden, rol
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="2970-d7cf-786c-eef2" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="857d-8c52-2aec-4d4" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="857d-8c52-2aec-4d4" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="1ade-2c0d-1b4a-8525" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="ae91-540d-91b5-7081" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
@@ -3453,7 +3490,7 @@ If an Enemy warrior is attempting to detect the bandit While he is Hidden, rol
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="b224-98d6-264e-e68a" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="6ace-f201-9c83-8021" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="9a0b-f275-8d55-f506" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="9a0b-f275-8d55-f506" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -3505,7 +3542,7 @@ If an Enemy warrior is attempting to detect the bandit While he is Hidden, rol
                 <modifier type="set" value="Pistol *" field="name"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="4dfd-89bc-7358-29ac" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="4dfd-89bc-7358-29ac" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="Dueling Pistol *" field="name"/>
               </modifiers>
@@ -3517,7 +3554,7 @@ If an Enemy warrior is attempting to detect the bandit While he is Hidden, rol
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="57af-e50d-defe-23e6" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="77c3-a34a-147-c69" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="77c3-a34a-147-c69" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="8fee-325e-5f59-c619" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="79ce-96a9-6bee-319e" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="1dfa-6111-7baf-eda7" type="selectionEntry" targetId="0871-44c2-f0f0-c27a">
@@ -3554,7 +3591,7 @@ If an Enemy warrior is attempting to detect the bandit While he is Hidden, rol
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="7339-7fa4-7a48-efcc" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="18ae-56aa-7770-79ba" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="df20-64f6-bb87-94b9" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="df20-64f6-bb87-94b9" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
           </entryLinks>
           <constraints>
             <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="b27f-5d4c-c936-2270"/>

--- a/Horned Hunters.cat
+++ b/Horned Hunters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="e37c-460d-d517-b3b7" name="Horned Hunters (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="e37c-460d-d517-b3b7" name="Horned Hunters (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="c32b-f67-ea0b-c818" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -130,7 +130,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
           <entryLinks>
             <entryLink id="7425-4e98-a617-4b31" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink id="8634-7dd0-3e82-80be" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink id="2db8-a90b-f150-e8f1" name="Hammer, staff, mace or club" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink id="2db8-a90b-f150-e8f1" name="Hammer" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Mace, Hammer"/>
               </modifiers>
@@ -163,7 +163,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
         </selectionEntryGroup>
         <selectionEntryGroup id="ea60-9443-2154-26e8" name="Armor" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="a916-e616-442d-ef12" name="Light Armor" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry"/>
+            <entryLink id="a916-e616-442d-ef12" name="Light Armour" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry"/>
             <entryLink import="true" name="Toughened Leathers" hidden="false" type="selectionEntry" id="29db-c6ef-baae-dcf2" targetId="439f-1b4d-1579-14b"/>
             <entryLink import="true" name="Shield" hidden="false" type="selectionEntry" id="acb3-5c8e-31ff-dc58" targetId="74fb-cc90-1361-df26"/>
           </entryLinks>
@@ -193,7 +193,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
           <entryLinks>
             <entryLink id="50c5-8397-2ab3-6d28" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink id="61e8-4cf8-9227-272a" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink id="c0a7-99d8-f8a6-d250" name="Hammer, staff, mace or club" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink id="c0a7-99d8-f8a6-d250" name="Hammer" hidden="false" collective="false" import="true" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Mace, Hammer"/>
               </modifiers>
@@ -513,7 +513,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
         <infoLink name="Strictures" hidden="false" type="rule" id="2601-4249-aa3a-743c" targetId="572d-9f68-ed41-e5b7"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="2f75-e48b-5d-4c5c" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="2f75-e48b-5d-4c5c" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="3fa5-fc41-ecea-e26f" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -681,7 +681,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
         <infoLink name="Hang the Bandit!" hidden="false" type="rule" id="ac28-204a-9687-2982" targetId="86f4-b849-8459-5685"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ec12-cffa-d70d-78d4" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="ec12-cffa-d70d-78d4" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e77f-f63b-dcab-2e1f" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -847,7 +847,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
         <infoLink name="Hang the Bandit!" hidden="false" type="rule" id="13c9-a18b-daf7-ea32" targetId="86f4-b849-8459-5685"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="6319-3b90-2368-c14" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="6319-3b90-2368-c14" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="da9b-54b6-e74f-9320" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1008,7 +1008,7 @@ Enemy models must halve their Initiative when attempting to find this warrior w
         <infoLink id="c92c-5d52-38c1-29c6" name="Human max" hidden="false" targetId="d9c2-4427-8e2b-586a" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1a4a-f244-ec92-b2db" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="1a4a-f244-ec92-b2db" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5bd7-2b96-1a84-a51c" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1176,7 +1176,7 @@ As such, they automatically pass all Leadership-based tests they are required 
         <infoLink name="Strictures" hidden="false" type="rule" id="dba1-3a02-7015-4b4d" targetId="572d-9f68-ed41-e5b7"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="4287-dafd-3fd5-a936" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="4287-dafd-3fd5-a936" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="87fa-d684-71dd-95aa" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
@@ -1334,7 +1334,7 @@ As such, they automatically pass all Leadership-based tests they are required 
         <infoLink name="Animals" hidden="false" type="rule" id="5dad-216b-a90f-a47e" targetId="daaa-38f1-8c4c-3140"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c76-6861-28f6-8e12" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="c76-6861-28f6-8e12" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15"/>
@@ -1353,7 +1353,7 @@ As such, they automatically pass all Leadership-based tests they are required 
         <categoryLink name="Stash" hidden="false" id="9b1-edef-a3f2-83c3" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="7194-29e1-8c0f-e4d9" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="7194-29e1-8c0f-e4d9" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="4287-9391-6add-999e" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="24ae-4ab1-c22c-451a" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -1361,6 +1361,27 @@ As such, they automatically pass all Leadership-based tests they are required 
         <cost name="pts" hidden="false" id="f0fd-6f99-cdfa-9833" typeId="points" value="0"/>
         <cost name="Warband Rating" hidden="false" id="6fde-34ae-ecc4-bca3" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="4bcc-7254-fee1-ad1a" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="7859-dd18-f3ea-5aa3" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="f4dd-5566-259e-f8c2-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="f4dd-5566-259e-f8c2-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Woodcraft" id="a823-5784-7d85-4332" hidden="false">
+          <description>Followers of Taal make their homes in the wilderness and shall only frequent towns or cities when it is compulsory for them to do so.
+They are expert woodsmen and their knowledge of the wilds is unrivalled by all except perhaps the Wood Elves.
+
+
+Horned Hunter warbands move through any difficult terrain they encounter without suffering any movement penalties.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="aff2-e7d6-533e-6bfe" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedRules>

--- a/Imperial Outriders.cat
+++ b/Imperial Outriders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="164f-72b5-751f-173c" name="Imperial Outriders (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="164f-72b5-751f-173c" name="Imperial Outriders (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="b628-2277-89a3-d4fd" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -181,7 +181,7 @@ For instance, a warrior with Ride Horse would need to gain the skill Ride Warh
         <entryLink import="true" name="Knight Equipment" hidden="false" id="8936-3bf5-8ad8-4c57" collective="false" targetId="7b01-ce7a-a09e-974b" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="39f8-ab02-34a5-763" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="e2c6-5680-110a-db89" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="8db7-c26-765f-62f7" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="8db7-c26-765f-62f7" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -495,7 +495,7 @@ For instance, a warrior with Ride Horse would need to gain the skill Ride Warh
         <entryLink import="true" name="Outriders Equipment" hidden="false" id="eecd-1a85-70d1-4e3f" collective="false" targetId="ff87-f2c2-4125-db19" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="9a54-5293-70aa-e88c" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="9e8d-3b1b-5eb9-eecc" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="8126-8f80-bd5f-7afe" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="8126-8f80-bd5f-7afe" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -845,7 +845,7 @@ For instance, a warrior with Ride Horse would need to gain the skill Ride Warh
         <entryLink import="true" name="Scouts Equipment" hidden="false" id="c411-4938-9fe9-af25" collective="false" targetId="e404-bff4-d1e4-a791" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="b74-6b3d-4c08-42ef" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="f67e-7a31-24d3-c997" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="754f-ef5f-4c23-9449" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="754f-ef5f-4c23-9449" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1234,7 +1234,7 @@ For instance, a warrior with Ride Horse would need to gain the skill Ride Warh
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Chasseurs Equipment" hidden="false" id="45b8-d6f4-b6d9-dcdf" collective="false" targetId="3d49-4d51-5282-648c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="5c0c-7fa1-fe5b-30a5" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="5c0c-7fa1-fe5b-30a5" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1680,7 +1680,7 @@ For instance, a warrior with Ride Horse would need to gain the skill Ride Warh
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Knight Equipment" hidden="false" id="3754-7b19-8b2b-3a39" collective="false" targetId="7b01-ce7a-a09e-974b" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="242b-add9-1519-25dc" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="242b-add9-1519-25dc" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2165,7 +2165,7 @@ This counts as an academic skill.</description>
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Chasseurs Equipment" hidden="false" id="d77f-13d0-4101-8913" collective="false" targetId="3d49-4d51-5282-648c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="a20d-b0be-834a-c356" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="a20d-b0be-834a-c356" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2443,16 +2443,39 @@ This counts as an academic skill.</description>
         <constraint type="max" value="2" field="selections" scope="roster" shared="true" id="aff3-80bb-3569-a79a" includeChildSelections="true"/>
       </constraints>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="82da-a20a-d599-67a9" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="ae81-3ee4-00ad-3e71" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="a6ba-14ae-d26e-0996-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="a6ba-14ae-d26e-0996-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hired Swords" id="5148-3839-fcf1-42ff" hidden="false">
+          <description>The Imperial Outriders may only be accompanied by mounted Hired Swords.
+
+
+This includes the Freelance Knight from the Mordheim Rulebook and the Roadwarden from the Empire In Flames supplement.
+
+
+The Highwayman keeps himself A safe distance from any official representatives of the Empire and so may not be hired.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="4cf0-ca0f-6161-72a8" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Armor" hidden="false" id="927d-c3ba-f0df-9647" collective="false" import="true">
       <entryLinks>
-        <entryLink import="true" name="Light Armor" hidden="false" id="6ab8-8315-d263-ea87" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+        <entryLink import="true" name="Light Armour" hidden="false" id="6ab8-8315-d263-ea87" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
         <entryLink import="true" name="Helmet" hidden="false" id="7bab-3f1-ee68-2ca0" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
         <entryLink import="true" name="Barding" hidden="false" id="2450-c5bd-2cd2-3ff6" type="selectionEntry" targetId="98cf-5b49-a433-c337"/>
         <entryLink import="true" name="Buckler" hidden="false" id="df49-a6c0-744d-201b" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
         <entryLink import="true" name="Gromril Armour" hidden="false" id="1607-9b1d-b143-a5bf" type="selectionEntry" targetId="4c6d-eb92-53a7-a6d3"/>
-        <entryLink import="true" name="Heavy Armor" hidden="false" id="bfa2-4ffa-123-6280" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6"/>
+        <entryLink import="true" name="Heavy Armour" hidden="false" id="bfa2-4ffa-123-6280" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6"/>
         <entryLink import="true" name="Ithilmar Armour" hidden="false" id="40bd-3498-9e43-7c07" type="selectionEntry" targetId="b0bd-108f-d18d-a2c7"/>
         <entryLink import="true" name="Shield" hidden="false" id="b9d6-da67-d444-dda4" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
       </entryLinks>
@@ -2461,7 +2484,7 @@ This counts as an academic skill.</description>
       <entryLinks>
         <entryLink import="true" name="Dagger" hidden="false" id="6c6e-7838-3656-ddf2" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
         <entryLink import="true" name="Free Dagger" hidden="false" id="877e-bd07-95ba-3db8" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-        <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="587d-6618-ba3a-bfea" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+        <entryLink import="true" name="Hammer" hidden="false" id="587d-6618-ba3a-bfea" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
           <modifiers>
             <modifier type="set" value="Hammer" field="name"/>
           </modifiers>

--- a/Kislevites.cat
+++ b/Kislevites.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9632-7414-5d8a-43cd" name="Kislevites (1a)" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="9632-7414-5d8a-43cd" name="Kislevites (1a)" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="5164-95fd-8401-79b9" name="Kislevites Rules" shortName="Kislevites" publisher="https://broheim.net/downloads/warbands/official/Kislevites.pdf" publisherUrl="https://broheim.net/downloads/warbands/official/Kislevites.pdf"/>
   </publications>
@@ -1971,6 +1971,33 @@ If any of these results are rolled for the Bear Tamer, treat the result as a &ap
           </modifiers>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="5f0d-1a51-0c34-91a9" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="9857-230c-19b6-3374" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="1be5-a784-a3af-aa9d-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="1be5-a784-a3af-aa9d-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Ancient Enemies" id="80ee-aa43-418d-0f89" hidden="false">
+          <description>Kilsevites warbands may nevet ally (see the &apos;Multiplayer rules for Mordheim&apos; article from Town Cryer for more details on warband alliances) with any type of Chaos warband.
+This restriction pertains to the following warbands:
+  Possessed,
+  Beastman,
+  Skaven,
+  Dark Elf,
+  Chaos Dwarf,
+and any other warbands the players judge to be sufficiently &apos;Chaotic&apos;</description>
+        </rule>
+        <rule name="May Hire" id="ecda-96fc-edaf-90a7" hidden="false">
+          <description>A Kilsevite warband is allowed the same selection of Hired Swords as the Human Mercenary warbands from the Mordheim rulebook.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="65b8-bf8a-53c5-3ecf" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Lizardmen.cat
+++ b/Lizardmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0845-6af8-5c39-3866ce12-79a1-424c-bda6" name="Lizardmen (1b)" revision="10" battleScribeVersion="2.03" authorName="David Brown" authorContact="Twitter: @dabrown_us" authorUrl="http://dabrown.us" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="0845-6af8-5c39-3866ce12-79a1-424c-bda6" name="Lizardmen (1b)" revision="11" battleScribeVersion="2.03" authorName="David Brown" authorContact="Twitter: @dabrown_us" authorUrl="http://dabrown.us" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="889151de-4826-5f00-5dbb-fcf546ebedbb" name="Kroxigor" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -2175,6 +2175,19 @@
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="d00f-f3c8-5c00-2237" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="82e5-2c4c-fdf9-67ad" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="5f65-738b-ef7f-edd5-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="5f65-738b-ef7f-edd5-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="e65c-2d6a-25ce-3309" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+        <infoLink name="Poisoned Weapons" id="25fd-54ec-7026-4321" hidden="false" targetId="0838-2e59-470f-c282" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <infoLinks>

--- a/Lustrian Reavers.cat
+++ b/Lustrian Reavers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="c182-5974-6237-14b7" name="Lustrian Reavers (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="c182-5974-6237-14b7" name="Lustrian Reavers (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="6c3-139a-972a-2bf5" targetId="e020-c282-277b-b173"/>
     <catalogueLink type="catalogue" name="Characters" id="ab7-e674-4718-461e" targetId="9bf78c55-7dba-4a44-90ce-10ed57d8b3a1"/>
@@ -11,7 +11,7 @@
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="1622-30dc-6ac2-8bf0" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="24cb-175c-b0e0-8fdd" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="2d6a-7c43-114-68b0" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="4">
+            <entryLink import="true" name="Hammer" hidden="false" id="2d6a-7c43-114-68b0" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="4">
               <modifiers>
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
@@ -38,7 +38,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="da79-f983-ad00-98e7" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="1e4b-3a71-3f57-5c47" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="1e4b-3a71-3f57-5c47" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="2cc-fee5-1a8e-c766" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="2">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
@@ -50,7 +50,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Missile weapons" id="836c-6159-8445-5268" hidden="false" sortIndex="2">
           <entryLinks>
-            <entryLink import="true" name="Javelins/Harpoons" hidden="false" id="7f54-d2c6-f17a-78b1" type="selectionEntry" targetId="ece5-fffa-8dd8-94dc" sortIndex="1">
+            <entryLink import="true" name="Javelins" hidden="false" id="7f54-d2c6-f17a-78b1" type="selectionEntry" targetId="ece5-fffa-8dd8-94dc" sortIndex="1">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
               </modifiers>
@@ -93,7 +93,7 @@
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="ac6c-eba2-2c83-633b" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="1c20-38cd-e9d1-e344" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="b471-f0c8-e2e5-2388" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="4">
+            <entryLink import="true" name="Hammer" hidden="false" id="b471-f0c8-e2e5-2388" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="4">
               <modifiers>
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
@@ -126,7 +126,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="b66-9ac8-80df-6f55" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="e123-6eb1-9a9-a43b" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="e123-6eb1-9a9-a43b" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="b5a6-da16-6295-8dbf" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="2">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
@@ -1187,7 +1187,7 @@ This ability can save the Conqueror only one time.</description>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="Heavy Armor" hidden="false" id="1e45-959f-2518-4434" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="9">
+        <entryLink import="true" name="Heavy Armour" hidden="false" id="1e45-959f-2518-4434" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="deb-2325-3dd4-7053" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9e3e-cf94-2c9c-db57" includeChildSelections="false"/>
@@ -1698,7 +1698,7 @@ This ability can save the Conqueror only one time.</description>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="Heavy Armor" hidden="false" id="a1da-9be-13a0-629d" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="9">
+        <entryLink import="true" name="Heavy Armour" hidden="false" id="a1da-9be-13a0-629d" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1ed2-e1c2-7a7f-2e00" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cf84-995d-6540-5664" includeChildSelections="false"/>
@@ -2318,7 +2318,7 @@ If you make the Jungle Shadow a Wizard, remove the Light Armour from the equip
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="Javelins/Harpoons" hidden="false" id="b031-67ee-d30f-6e20" type="selectionEntry" targetId="ece5-fffa-8dd8-94dc" sortIndex="10">
+        <entryLink import="true" name="Javelins" hidden="false" id="b031-67ee-d30f-6e20" type="selectionEntry" targetId="ece5-fffa-8dd8-94dc" sortIndex="10">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="82f2-4238-3313-5d18" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="eeaf-4c72-add3-a23f" includeChildSelections="false"/>
@@ -2327,7 +2327,7 @@ If you make the Jungle Shadow a Wizard, remove the Light Armour from the equip
             <modifier type="set" value="0" field="points"/>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="Light Armor" hidden="false" id="8b54-2f75-800e-2fe0" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="11">
+        <entryLink import="true" name="Light Armour" hidden="false" id="8b54-2f75-800e-2fe0" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="11">
           <modifiers>
             <modifier type="set" value="0" field="points"/>
             <modifier type="set" value="true" field="hidden">
@@ -2814,7 +2814,7 @@ This does not work with Blackpowder weapons.</description>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="Heavy Armor" hidden="false" id="4476-891d-9c9-2f27" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="9">
+        <entryLink import="true" name="Heavy Armour" hidden="false" id="4476-891d-9c9-2f27" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="deb-2325-3dd4-7053" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9e3e-cf94-2c9c-db57" includeChildSelections="false"/>
@@ -3093,6 +3093,46 @@ Remove the counters when the trap is sprung.</description>
       <constraints>
         <constraint type="max" value="5" field="selections" scope="roster" shared="true" id="5914-a073-abeb-6b2e" includeChildSelections="true"/>
       </constraints>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="72fb-1612-f6c0-5037" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="e0f5-0a20-860d-854b" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="796f-17e9-88d4-d4d5-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="796f-17e9-88d4-d4d5-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hired Swords" id="9d52-8fb1-df07-e69d" hidden="false">
+          <description>The Lustrian Reavers are proud and suspicious, and therefore rarely use Hired Swords.
+
+
+They may hire an Ogre Bodyguard, Dwarf Trollslayer, Tilean Marksman or a Big Game Hunter.</description>
+        </rule>
+        <rule name="Promotions" id="49d6-286e-b4e5-1c97" hidden="false">
+          <description>When you lose one of the Heroes for whatever reason, you cannot buy a new one. 
+However, you retain all the equipment of the fallen Hero, and you may now promote one of the Prospects into the role of the lost hero, as if that Henchman just successfully rolled Lad’s Got Talent on the Henchmen Advancement Table: 
+
+
+You may choose two skill lists available to Heroes in your warband.
+These are the skill types your new Hero can choose from when the model gains new skills.
+The new Hero can immediately make one roll on the Heroes Advance table.
+The new Hero then gains the armor, weapons, (but not the equipment) of the fallen Hero and assumes their position the Warband.
+The Prospect’s own equipment may be added to the Warband stash.
+
+
+If you have no Prospect currently in you Warband, you can promote the next one you hire.</description>
+        </rule>
+        <rule name="Rare Heroes" id="8d28-b5ea-d011-7205" hidden="false">
+          <description>You can only ever buy one of each type of Heroes during the existence of your Warband, representing the extreme rarity of these the toughest of survivors of Lustria.
+
+
+The Heroes are bought with the weapons and armor listed under their entry, and can never swap or give away these, though you may acquire new equipment, weapons and armor to them if you wish.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="f8b4-baf3-afb7-3b71" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Maneaters.cat
+++ b/Maneaters.cat
@@ -1,102 +1,102 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4487-2770-d9cd-ea0b" name="Maneaters (1c)" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4487-2770-d9cd-ea0b" name="Maneaters (1c)" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="ea05-7e6b-115f-542a" name="Captain" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1249-c408-07db-5a84" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8322-c453-c542-2d8a" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1249-c408-07db-5a84" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8322-c453-c542-2d8a" type="max"/>
       </constraints>
       <profiles>
         <profile id="e96e-0384-afa5-869b" name="Captain" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ea05-7e6b-115f-542a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -117,29 +117,29 @@
         <infoLink id="ebce-b066-d48a-6cd3" name="Fear" hidden="false" targetId="cdc8-da3b-a2ed-d841" type="rule"/>
         <infoLink id="7403-e457-e7fc-2e4e" name="Large Target" hidden="false" targetId="069e-ecc0-275d-765c" type="rule"/>
         <infoLink id="9432-f767-17f1-4247" name="Leader" hidden="false" targetId="8712-d0f2-fe64-07bd" type="rule"/>
-        <infoLink id="72a2-5906-5203-421a" name="Orge max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
+        <infoLink id="72a2-5906-5203-421a" name="Ogre max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="934e-08df-c67f-abd2" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="934e-08df-c67f-abd2" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6d9d-31dc-d9ed-120d" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825c-6486-7a2a-d5da" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325b-17ed-63bc-daa6" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825c-6486-7a2a-d5da" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325b-17ed-63bc-daa6" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="c4bd-7949-1b59-1e59" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d99a-2ee3-affe-2a77" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ab-61a8-47a1-c0a1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b0-3018-d9a5-1b82" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ab-61a8-47a1-c0a1" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b0-3018-d9a5-1b82" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b30d-bac0-ffc3-2671" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
@@ -147,15 +147,15 @@
             <entryLink id="dde9-a9ad-3969-2770" name="Special Skills (Maneaters)" hidden="false" collective="false" import="true" targetId="7228-d089-dfaf-7ef9" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="14ca-1dc0-d2f0-ee8d" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b68-4bc3-f453-f34d" type="min"/>
+            <constraint field="selections" scope="parent" value="20" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b68-4bc3-f453-f34d" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="07c0-e09a-6ebc-0b39" name="Ogre Equipment" hidden="false" collective="false" import="true" targetId="fc22-e3cb-e7e1-d47f" type="selectionEntryGroup"/>
@@ -163,105 +163,105 @@
         <entryLink id="358d-ac4f-bb01-4227" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="Warband Rating" typeId="wb-rating" value="20.0"/>
-        <cost name="pts" typeId="points" value="145.0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="20"/>
+        <cost name="pts" typeId="points" value="145"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f8d0-3e0f-eaf0-edf2" name="Mountain Guide" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d7d-f138-5a16-a449" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d7d-f138-5a16-a449" type="max"/>
       </constraints>
       <profiles>
         <profile id="bba2-8814-b953-09c7" name="Mountain Guide" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f8d0-3e0f-eaf0-edf2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -297,29 +297,29 @@ They are immune to All Alone tests and may never become the warband leader.</des
       <infoLinks>
         <infoLink id="50e0-d4c2-ae79-b0dd" name="Fear" hidden="false" targetId="cdc8-da3b-a2ed-d841" type="rule"/>
         <infoLink id="4ef0-b793-91b7-244d" name="Large Target" hidden="false" targetId="069e-ecc0-275d-765c" type="rule"/>
-        <infoLink id="8922-0cc0-681d-d9d5" name="Orge max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
+        <infoLink id="8922-0cc0-681d-d9d5" name="Ogre max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="230d-427b-d20b-88ac" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="230d-427b-d20b-88ac" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fec1-6194-abd9-7504" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c4c-75a7-ac9d-dd35" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bff-7bbd-3602-e3e2" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c4c-75a7-ac9d-dd35" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bff-7bbd-3602-e3e2" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3537-4714-4ed4-5de4" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="50fe-1a67-6efd-f584" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b9-d250-6368-07b9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c036-67cc-d7fc-e552" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b9-d250-6368-07b9" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c036-67cc-d7fc-e552" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="9452-8328-5c0a-57fe" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
@@ -327,15 +327,15 @@ They are immune to All Alone tests and may never become the warband leader.</des
             <entryLink id="bcad-7b8a-ce14-3eb0" name="Special Skills (Maneaters)" hidden="false" collective="false" import="true" targetId="7228-d089-dfaf-7ef9" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="fbd1-e4d3-d02b-9659" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf2-dd72-e045-21a4" type="min"/>
+            <constraint field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf2-dd72-e045-21a4" type="min"/>
           </constraints>
         </entryLink>
         <entryLink id="e085-47fb-ce0e-20ad" name="Guide Equipment" hidden="false" collective="false" import="true" targetId="9a10-f869-0d32-c190" type="selectionEntryGroup"/>
@@ -343,105 +343,105 @@ They are immune to All Alone tests and may never become the warband leader.</des
         <entryLink id="e071-b435-5b96-2d2e" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="Warband Rating" typeId="wb-rating" value="20.0"/>
-        <cost name="pts" typeId="points" value="145.0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="20"/>
+        <cost name="pts" typeId="points" value="145"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cf6d-fa3b-39e7-badc" name="Youngbloods" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b35-d136-d01e-48e7" type="max"/>
+        <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b35-d136-d01e-48e7" type="max"/>
       </constraints>
       <profiles>
         <profile id="86e1-fb5e-b0cf-7199" name="Youngbloods" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="cf6d-fa3b-39e7-badc" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -459,29 +459,29 @@ They are immune to All Alone tests and may never become the warband leader.</des
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="e84b-7736-7c18-8e76" name="Orge max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
+        <infoLink id="e84b-7736-7c18-8e76" name="Ogre max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="53f9-7679-1ef3-c0ac" name="New CategoryLink" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
+        <categoryLink id="53f9-7679-1ef3-c0ac" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c995-2cd0-b3f4-0f41" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b6-549b-db48-c9bb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2729-8924-78cc-ecbf" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b6-549b-db48-c9bb" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2729-8924-78cc-ecbf" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="1dc2-80a4-2663-cb12" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7053-47c8-a460-c1d1" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e541-3f72-1282-4cbc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d1e-ed36-ea28-7923" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e541-3f72-1282-4cbc" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d1e-ed36-ea28-7923" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="fe82-6fb0-e256-b4c5" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
@@ -489,8 +489,8 @@ They are immune to All Alone tests and may never become the warband leader.</des
             <entryLink id="6efe-86ec-3665-ada2" name="Special Skills (Maneaters)" hidden="false" collective="false" import="true" targetId="7228-d089-dfaf-7ef9" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -501,8 +501,8 @@ They are immune to All Alone tests and may never become the warband leader.</des
         <entryLink id="e662-a0d5-5925-dd1c" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name="pts" typeId="points" value="45.0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name="pts" typeId="points" value="45"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8737-06c4-b1a7-9dc2" name="Half-growns" hidden="false" collective="false" import="true" type="model">
@@ -511,92 +511,92 @@ They are immune to All Alone tests and may never become the warband leader.</des
           <modifiers>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8737-06c4-b1a7-9dc2" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -615,23 +615,23 @@ They are immune to All Alone tests and may never become the warband leader.</des
       </profiles>
       <infoLinks>
         <infoLink id="92e1-7fdc-98e8-8960" name="Fear" hidden="false" targetId="cdc8-da3b-a2ed-d841" type="rule"/>
-        <infoLink id="05e1-de56-5102-81c0" name="Orge max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
+        <infoLink id="05e1-de56-5102-81c0" name="Ogre max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="03f4-9248-3120-e514" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="03f4-9248-3120-e514" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7366-9e9e-81c0-3f6c" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99e-7076-7d60-7658" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71cf-9332-79ce-fb3d" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99e-7076-7d60-7658" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71cf-9332-79ce-fb3d" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="3699-1299-97ca-4339" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -644,7 +644,7 @@ They are immune to All Alone tests and may never become the warband leader.</des
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -653,27 +653,27 @@ They are immune to All Alone tests and may never become the warband leader.</des
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name="pts" typeId="points" value="85.0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name="pts" typeId="points" value="85"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="71b3-727e-a0c1-c0cb" name="Sabretusks" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="17f2-8d0c-3397-3aca" value="2.0">
+        <modifier type="set" field="17f2-8d0c-3397-3aca" value="2">
           <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f8d0-3e0f-eaf0-edf2" type="equalTo"/>
+            <condition field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f8d0-3e0f-eaf0-edf2" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f2-8d0c-3397-3aca" type="max"/>
+        <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f2-8d0c-3397-3aca" type="max"/>
       </constraints>
       <profiles>
         <profile id="2e06-4e4a-e679-ee90" name="Sabretusks" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
@@ -713,111 +713,111 @@ An uncontrolled Sabretusk may charge models from his own warband!</description>
         <infoLink id="92d5-7e81-6a90-897e" name="Animals" hidden="false" targetId="daaa-38f1-8c4c-3140" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9366-78fe-a15b-12d9" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="9366-78fe-a15b-12d9" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="b7e8-b785-e998-9a9f" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name="pts" typeId="points" value="125.0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name="pts" typeId="points" value="125"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="02b5-2ebd-abd3-cf6a" name="Bulls" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d9b-9663-a1d7-6d88" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d9b-9663-a1d7-6d88" type="max"/>
       </constraints>
       <profiles>
         <profile id="5972-81ea-81ca-71c1" name="Bulls" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="02b5-2ebd-abd3-cf6a" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -844,23 +844,23 @@ If successful the enemy model is automatically knocked down.</description>
       <infoLinks>
         <infoLink id="d123-ece0-d0d3-62f3" name="Fear" hidden="false" targetId="cdc8-da3b-a2ed-d841" type="rule"/>
         <infoLink id="5dac-e341-5297-362d" name="Large Target" hidden="false" targetId="069e-ecc0-275d-765c" type="rule"/>
-        <infoLink id="9b99-e830-86d9-b351" name="Orge max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
+        <infoLink id="9b99-e830-86d9-b351" name="Ogre max" hidden="false" targetId="2fa4-2362-07c1-3433" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="1725-29da-11b6-61fa" name="New CategoryLink" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
+        <categoryLink id="1725-29da-11b6-61fa" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9dc2-3df7-7b2a-f121" name="Extra Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f5a-3486-3d66-bc77" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcf5-fc87-cb42-a4ab" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f5a-3486-3d66-bc77" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcf5-fc87-cb42-a4ab" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="06aa-b02d-7e1e-ef56" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -873,7 +873,7 @@ If successful the enemy model is automatically knocked down.</description>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -882,34 +882,74 @@ If successful the enemy model is automatically knocked down.</description>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Warband Rating" typeId="wb-rating" value="20.0"/>
-        <cost name="pts" typeId="points" value="140.0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="20"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1e73-9980-56e2-b129" name="Stash" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9672-2ffb-8d1b-02d3" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98e6-3803-d09c-8f98" type="max"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9672-2ffb-8d1b-02d3" type="min"/>
+        <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98e6-3803-d09c-8f98" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="68a7-0da7-c574-49ae" name="New CategoryLink" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+        <categoryLink id="68a7-0da7-c574-49ae" name="Stash" hidden="false" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="45ab-498d-c7bb-49e6" name="Gold" hidden="false" collective="false" import="true" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink id="45ab-498d-c7bb-49e6" name="Variable Gold Cost" hidden="false" collective="false" import="true" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink id="df9f-b323-fc3b-4db7" name="Wyrdstone" hidden="false" collective="false" import="true" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
-        <entryLink id="3e01-b258-354f-70d5" name="Looted Equip" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
+        <entryLink id="3e01-b258-354f-70d5" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="65d2-feb8-3687-0dd0" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="e91f-dd2c-b3c6-0cef" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="8b3e-03d7-a34d-362f-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="8b3e-03d7-a34d-362f-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Cannibals" id="d8f5-0b73-af9a-8d04" hidden="false">
+          <description>Most Hired Swords refuse to work for Ogres, as they know for sure they’ll end up being a meal sooner or later.
+An Ogre warband may never hire any Hired Swords, except for Halflings (Scout, Thief, etc.) and the Ogre Bodyguard, or unless stated otherwise, in which case Ogres can choose to devour him when the contract ends (see Gluttony).</description>
+        </rule>
+        <rule name="Difficult Customers" id="109b-a459-a13d-0f8f" hidden="false">
+          <description>Unable to create anything of lasting worth, Ogres tend to rely on more civilised folk for the acquisition of quality goods.
+Widely regarded by vendors as their least popular and most frightening customers, Ogre Heroes suffer -1 when rolling to find Rare items that are not exclusively available to Ogres.</description>
+        </rule>
+        <rule name="Gluttony" id="3ed2-6cd7-9917-10bf" hidden="false">
+          <description>Because of a voracious appetite, each Ogre model counts as two models when selling wyrdstone or treasure.
+
+Any model which is captured due to Serious Injuries or Exploration can be devoured and his possessions retained, reducing the combined model count of your warband by one (or two if the captive ‘shared meal’ is a Large Target).
+
+Each Ogre always counts as at least one model towards the total, no matter how much he eats!
+
+An Ogre Hero devouring captured models is granted experience points equal to the number of models that were consumed.
+
+Any member or animal (including mounts) from your warband can be eaten in the same way!
+Remove any consumed comrades from the warband roster immediately.</description>
+        </rule>
+        <rule name="Slow Witted" id="d3f0-eec5-8d60-68bb" hidden="false">
+          <description>Although Ogres are capable of earning experience and bettering themselves they are not the smartest of creatures.
+Ogres only improve at half the rate of everyone else.
+
+They must earn twice the usual number of experience points to gain an advance.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="1b62-3998-6bb1-178b" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>
@@ -969,8 +1009,8 @@ This means that an iron fist allows the wearer to re-roll failed parry attempts 
         <infoLink id="e604-99db-382b-5438" name="Parry" hidden="false" targetId="17dc-9c49-08e1-af45" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="15.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="15"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="03c3-744d-3074-df49" name="Ogre Club" hidden="false" collective="false" import="true" type="upgrade">
@@ -998,8 +1038,8 @@ Crushing Attack only applies if the Ogre uses the club with both hands.</descrip
         <infoLink id="273a-43c2-ec83-62b1" name="Concussion" hidden="false" targetId="f08e-fc7a-fca1-6a49" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="10.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="10"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8bfe-e1cb-60de-6df3" name="Harpoon Crossbow" hidden="false" collective="false" import="true" type="upgrade">
@@ -1022,8 +1062,8 @@ Crushing Attack only applies if the Ogre uses the club with both hands.</descrip
         <infoLink id="998c-5b71-8029-08b5" name="Prepare shot" hidden="false" targetId="4f7f-29ec-a9da-82fc" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="50"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c169-0059-2b6b-a2f9" name="Hand-Held Mortar" hidden="false" collective="false" import="true" type="upgrade">
@@ -1053,8 +1093,8 @@ Crushing Attack only applies if the Ogre uses the club with both hands.</descrip
         <infoLink id="bbb6-28cf-9de1-d22a" name="Firearm save modifier" hidden="false" targetId="5d21-2b30-4219-ec86" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="80.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="80"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4230-9ecf-d7b1-637e" name="Lookout Gnoblar" hidden="false" collective="false" import="true" type="upgrade">
@@ -1069,8 +1109,8 @@ Crushing Attack only applies if the Ogre uses the club with both hands.</descrip
       <selectionEntries>
         <selectionEntry id="7334-15fd-39ca-7734" name="Dodge." page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f831-31b6-2392-37bd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ee-08fd-9032-a54d" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f831-31b6-2392-37bd" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ee-08fd-9032-a54d" type="min"/>
           </constraints>
           <rules>
             <rule id="55b5-3761-4862-fe89" name="Dodge." page="0" hidden="false">
@@ -1078,14 +1118,14 @@ Crushing Attack only applies if the Ogre uses the club with both hands.</descrip
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="20"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fb64-2749-b338-5d62" name="Luck Gnoblar" hidden="false" collective="false" import="true" type="upgrade">
@@ -1098,8 +1138,8 @@ Crushing Attack only applies if the Ogre uses the club with both hands.</descrip
         </rule>
       </rules>
       <costs>
-        <cost name="pts" typeId="points" value="25.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="25"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19a0-ec5f-4452-7e5b" name="Sword Gnoblar" hidden="false" collective="false" import="true" type="upgrade">
@@ -1114,8 +1154,8 @@ The opponent’s attention is on the Ogre!</description>
         </rule>
       </rules>
       <costs>
-        <cost name="pts" typeId="points" value="30.0"/>
-        <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name="pts" typeId="points" value="30"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1130,7 +1170,7 @@ The opponent’s attention is on the Ogre!</description>
     </selectionEntryGroup>
     <selectionEntryGroup id="38a7-86e8-c344-4b43" name="Hand-to-hand Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a63-3aab-542e-825c" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a63-3aab-542e-825c" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="443d-72db-3139-fd89" name="Sword" hidden="false" collective="false" import="true" targetId="34fd-d6a3-50ee-ee06" type="selectionEntry"/>
@@ -1148,7 +1188,7 @@ The opponent’s attention is on the Ogre!</description>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea05-7e6b-115f-542a" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea05-7e6b-115f-542a" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1157,20 +1197,20 @@ The opponent’s attention is on the Ogre!</description>
     </selectionEntryGroup>
     <selectionEntryGroup id="c792-d405-d20d-e744" name="Missile Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec75-3f12-7e6e-5647" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec75-3f12-7e6e-5647" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="3945-0c13-7250-8a85" name="Hand-Held Mortar" hidden="false" collective="false" import="true" targetId="c169-0059-2b6b-a2f9" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="70.0"/>
+            <modifier type="set" field="points" value="70"/>
           </modifiers>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="c1f1-74d6-68e7-0f3b" name="Armor" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="d79d-500f-c889-9e70" name="Light Armor" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry"/>
-        <entryLink id="2a4f-a2bf-35c6-181a" name="Heavy Armor" hidden="false" collective="false" import="true" targetId="4e34-bbc5-c7ef-6bd6" type="selectionEntry"/>
+        <entryLink id="d79d-500f-c889-9e70" name="Light Armour" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry"/>
+        <entryLink id="2a4f-a2bf-35c6-181a" name="Heavy Armour" hidden="false" collective="false" import="true" targetId="4e34-bbc5-c7ef-6bd6" type="selectionEntry"/>
         <entryLink id="2f80-a2e4-6ad3-0f8b" name="Helmet" hidden="false" collective="false" import="true" targetId="d0e5-ca89-5f0d-f5d2" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
@@ -1183,7 +1223,7 @@ The opponent’s attention is on the Ogre!</description>
     </selectionEntryGroup>
     <selectionEntryGroup id="5f07-2194-c600-bb09" name="Hand-to-hand Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4161-83ad-304b-ba2f" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4161-83ad-304b-ba2f" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="c3bd-7f60-7281-e6cd" name="Sword" hidden="false" collective="false" import="true" targetId="34fd-d6a3-50ee-ee06" type="selectionEntry"/>
@@ -1199,7 +1239,7 @@ The opponent’s attention is on the Ogre!</description>
     </selectionEntryGroup>
     <selectionEntryGroup id="2374-1c6f-090b-3a24" name="Missile Weapons" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3366-20ca-d2f7-1f21" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3366-20ca-d2f7-1f21" type="max"/>
       </constraints>
       <entryLinks>
         <entryLink id="c1c6-039a-e907-5a09" name="Harpoon Crossbow" hidden="false" collective="false" import="true" targetId="8bfe-e1cb-60de-6df3" type="selectionEntry"/>
@@ -1207,13 +1247,13 @@ The opponent’s attention is on the Ogre!</description>
     </selectionEntryGroup>
     <selectionEntryGroup id="f0df-c381-ac94-29c2" name="Armor" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="555b-3cc3-3eb6-10a5" name="Light Armor" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry"/>
+        <entryLink id="555b-3cc3-3eb6-10a5" name="Light Armour" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry"/>
         <entryLink id="2aca-636e-44c4-c03e" name="Helmet" hidden="false" collective="false" import="true" targetId="d0e5-ca89-5f0d-f5d2" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="8672-4b89-a288-1774" name="Miscellaneous" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa88-fb8b-1a4a-f644" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa88-fb8b-1a4a-f644" type="max"/>
       </constraints>
       <rules>
         <rule id="5fc0-8fb2-6f9c-ded2" name="Gnoblars" hidden="false">
@@ -1238,7 +1278,7 @@ These can be represented on the model they accompany.</description>
       <selectionEntries>
         <selectionEntry id="0513-532c-f77d-3b51" name="Master of Arms" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be57-e54c-9114-9eb9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be57-e54c-9114-9eb9" type="max"/>
           </constraints>
           <rules>
             <rule id="55a8-7719-d99d-cd2b" name="Master of Arms" hidden="false">
@@ -1247,13 +1287,13 @@ He may now wield a Difficult to Use weapon and a hand weapon at the same time, b
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c196-b638-10d8-85f6" name="Crude Belch" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b108-aefe-c276-8661" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b108-aefe-c276-8661" type="max"/>
           </constraints>
           <rules>
             <rule id="e50c-af19-f76b-0b26" name="Crude Belch" hidden="false">
@@ -1265,20 +1305,20 @@ The Ogre must wait until a new enemy engages him incombat before he relieves him
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="85c9-2152-ff6e-8a68" name="Bull Charge" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="02b5-2ebd-abd3-cf6a" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="02b5-2ebd-abd3-cf6a" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cc3-8833-356c-8dee" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cc3-8833-356c-8dee" type="max"/>
           </constraints>
           <rules>
             <rule id="45b3-15ce-e279-b417" name="Bull Charge" hidden="false">
@@ -1288,20 +1328,20 @@ If successful the enemy model is automatically knocked down.</description>
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="76d1-b223-c318-4760" name="Dog of War" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea05-7e6b-115f-542a" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea05-7e6b-115f-542a" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3dc-593b-1787-2024" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3dc-593b-1787-2024" type="max"/>
           </constraints>
           <rules>
             <rule id="f8b5-ee82-ec91-f2a0" name="Dog of War" hidden="false">
@@ -1312,20 +1352,20 @@ This skill may only be taken by the leader and if he dies all Hired Swords are r
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d84a-b946-a476-6e8b" name="Bellowing Roar" hidden="true" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea05-7e6b-115f-542a" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea05-7e6b-115f-542a" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00a4-8406-bd96-eac3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00a4-8406-bd96-eac3" type="max"/>
           </constraints>
           <rules>
             <rule id="ad9d-9da3-0156-7eec" name="Bellowing Roar" hidden="false">
@@ -1335,8 +1375,8 @@ This skill may only be taken by the warband leader, allowing him to re-roll the 
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1345,12 +1385,12 @@ This skill may only be taken by the warband leader, allowing him to re-roll the 
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f8d0-3e0f-eaf0-edf2" type="instanceOf"/>
+                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f8d0-3e0f-eaf0-edf2" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bab8-779c-c70e-df22" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bab8-779c-c70e-df22" type="max"/>
           </constraints>
           <rules>
             <rule id="f16a-2a58-24ff-5652" name="Maneater" hidden="false">
@@ -1365,26 +1405,26 @@ This skill may be taken only once and may not be taken by the Guide.</descriptio
               <entryLinks>
                 <entryLink id="229f-67e2-5654-31f2" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b463-851e-4da7-3348" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b463-851e-4da7-3348" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7130-db80-b2cd-6763" name="Shooting Skills" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="9bc5-5995-8120-7d3f" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e857-a053-0f30-88ca" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e857-a053-0f30-88ca" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+                <cost name="pts" typeId="points" value="0"/>
+                <cost name="Warband Rating" typeId="wb-rating" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1393,44 +1433,44 @@ This skill may be taken only once and may not be taken by the Guide.</descriptio
     </selectionEntryGroup>
     <selectionEntryGroup id="d409-c1e4-d118-8109" name="Skills" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae3a-9497-6293-8d79" type="max"/>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1820-17b2-433b-efa2" type="min"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae3a-9497-6293-8d79" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1820-17b2-433b-efa2" type="min"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="3221-b415-0e98-d83b" name="Special Skills (Maneaters)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e1-1c6c-686d-1be3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e1-1c6c-686d-1be3" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="899a-db61-4f22-9ac5" name="Special Skills (Maneaters)" hidden="false" collective="false" import="true" targetId="7228-d089-dfaf-7ef9" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4092-b58d-771d-2f0b" name="Combat Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4edc-4319-ccb7-8f2a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4edc-4319-ccb7-8f2a" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="752d-2ee3-2609-ec78" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4855-006f-9c40-3770" name="Strength Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8714-31f9-cce7-147e" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8714-31f9-cce7-147e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="181d-1b07-7eaa-f202" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="Warband Rating" typeId="wb-rating" value="0.0"/>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>

--- a/Marienburg_Mercinaries.cat
+++ b/Marienburg_Mercinaries.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d7899d8b-a172-7e27-aec7-b9c51cb475c1" name="Marienburgers (1a)" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="d7899d8b-a172-7e27-aec7-b9c51cb475c1" name="Marienburgers (1a)" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Champion" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -1627,6 +1627,26 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="f80e-32a5-5f8f-8d43" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="0a44-8fd4-791b-58fa" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="54c4-4dcc-19c0-c56b-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="54c4-4dcc-19c0-c56b-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Great Traders" id="a1d8-fc5d-95b8-2289" hidden="false" page="0">
+          <description>As natural traders with contacts in the merchant guilds Marienburg warbands receive a +1 bonus when attempting to find rare items.
+To reflect their enormous wealth Marienburgers start off with an extra 100 gold crowns (600 in total) when fighting in a campaign.
+In a one-off game they are permitted an extra 20% gold crowns when recruiting a warband.
+For example, in a 1,000 gold crown game a Marienburger warband will have 1,200gc.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="866c-4d0c-23dd-4905" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Merchant Caravans.cat
+++ b/Merchant Caravans.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="3990-6810-2651-81b0" name="Merchant Caravans (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="3990-6810-2651-81b0" name="Merchant Caravans (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="3418-3f66-a3bc-d41e" targetId="e020-c282-277b-b173"/>
     <catalogueLink type="catalogue" name="New Catalogue (link)" id="87e6-d8d1-6fc3-6290" targetId="9bf78c55-7dba-4a44-90ce-10ed57d8b3a1"/>
@@ -52,7 +52,7 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="4392-49da-eeb6-1c18" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="7d69-3aff-825d-6d54" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="1987-479-6a0a-60be" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="1987-479-6a0a-60be" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -73,8 +73,8 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="2130-9379-5725-c0a" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="19f-513d-4f9f-bc16" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="73d3-ef05-29a6-8b5c" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
+            <entryLink import="true" name="Light Armour" hidden="false" id="19f-513d-4f9f-bc16" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="73d3-ef05-29a6-8b5c" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
               </modifiers>
@@ -85,7 +85,7 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
         </selectionEntryGroup>
         <selectionEntryGroup name="Missile weapons" id="7753-91dd-c5bc-622a" hidden="false" sortIndex="2">
           <entryLinks>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="eb2f-5342-6ae2-679f" type="selectionEntry" targetId="da24-6a7f-725b-5bcb" sortIndex="2"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="eb2f-5342-6ae2-679f" type="selectionEntry" targetId="da24-6a7f-725b-5bcb" sortIndex="2"/>
             <entryLink import="true" name="Pistol" hidden="false" id="b033-ad7e-b3e8-9d98" type="selectionEntry" targetId="67e9-a4f5-8f76-168c" sortIndex="1"/>
           </entryLinks>
           <constraints>
@@ -110,7 +110,7 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="f0bd-eabb-f7ec-86e4" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="85df-4f2-1585-493b" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="96b1-49a8-60a6-ddfc" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="96b1-49a8-60a6-ddfc" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -133,8 +133,8 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="980c-80ba-e038-20b8" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="6dca-5f13-8848-caa0" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="8e48-d39f-e456-c5a3" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
+            <entryLink import="true" name="Light Armour" hidden="false" id="6dca-5f13-8848-caa0" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="8e48-d39f-e456-c5a3" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
               </modifiers>
@@ -159,7 +159,7 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="cb1-1d2-d158-c64b" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="8744-e0ae-bdce-2895" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="b08a-1a64-2c0d-4421" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="b08a-1a64-2c0d-4421" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Club" field="name"/>
               </modifiers>
@@ -181,8 +181,8 @@ If players cannot agree on a price no deal is closed and the visit is wasted.<
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="98a9-6e0f-ea2d-9e9a" hidden="false" sortIndex="2">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="ff13-226f-4bf1-8020" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="6857-2d2d-1752-2d6b" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
+            <entryLink import="true" name="Light Armour" hidden="false" id="ff13-226f-4bf1-8020" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="6857-2d2d-1752-2d6b" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
               </modifiers>
@@ -294,7 +294,7 @@ Note that though the Merchant may buy items using the table above he can never s
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="184-bbd9-68cd-5062" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="3446-c2f-bb23-c8fb" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="e12f-fa46-8117-cef9" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="e12f-fa46-8117-cef9" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -317,8 +317,8 @@ Note that though the Merchant may buy items using the table above he can never s
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="92c1-4af9-1a58-4520" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="5b67-7ce7-d51c-2b27" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="21f9-33d1-e079-d09" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
+            <entryLink import="true" name="Light Armour" hidden="false" id="5b67-7ce7-d51c-2b27" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="21f9-33d1-e079-d09" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2">
               <modifiers>
                 <modifier type="set" value="10" field="points"/>
               </modifiers>
@@ -329,7 +329,7 @@ Note that though the Merchant may buy items using the table above he can never s
         </selectionEntryGroup>
         <selectionEntryGroup name="Missile weapons" id="a6aa-c1f1-1cb-dbeb" hidden="false" sortIndex="2">
           <entryLinks>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="64c5-d533-1624-ef1b" type="selectionEntry" targetId="da24-6a7f-725b-5bcb" sortIndex="2"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="64c5-d533-1624-ef1b" type="selectionEntry" targetId="da24-6a7f-725b-5bcb" sortIndex="2"/>
             <entryLink import="true" name="Pistol" hidden="false" id="8d7a-3133-3090-826e" type="selectionEntry" targetId="67e9-a4f5-8f76-168c" sortIndex="1"/>
           </entryLinks>
           <constraints>
@@ -2951,6 +2951,59 @@ A warband capturing a Wagon from a Merchant Caravan may not search for rare ite
       <categoryLinks>
         <categoryLink targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" id="7fb5-97da-bde4-5853" primary="true" name="Henchmen"/>
       </categoryLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="3b98-51f2-c64e-06fd" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="856c-b201-1ce9-f2dd" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="7c23-4b9d-c98e-06b8-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="7c23-4b9d-c98e-06b8-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hired Swords" id="ec00-7d68-a97e-71e3" hidden="false">
+          <description>Merchant Caravans may hire every Hired Sword that is available to Mercenary warbands.</description>
+        </rule>
+        <rule name="Open for Business" id="13eb-2df9-829e-2ae4" hidden="false">
+          <description>All players may choose to send any of their Heroes to the Merchant instead of having them search for rare items.
+
+
+A Hero doing so may buy one item from the warband&apos;s stored equipment if the players can agree on a price (including exchange deals with items and Treasures).
+
+
+Instead of buying an item a Hero may also go to the Merchant to sell any one item (rare, common, magical, treasure counters) to him.
+
+
+If players cannot agree on a price no deal is closed and the visit is wasted.</description>
+        </rule>
+        <rule name="Rarity" id="03d2-7459-ed8f-6f21" hidden="false">
+          <description>Any rare item that is reduced to Rare 2 or below by the Trade Wagon&apos;s Reputation rule, the Streetwise skill etc., can be bought as Common items.</description>
+        </rule>
+        <rule name="Trade" id="90a4-fdf5-548f-0bc5" hidden="false">
+          <description>Instead of searching for rare items the Merchant may sell a rare item that has been stored in the Trade Cart during the preceding battle.
+
+
+This must be done before Heroes of either warband search for rare items.
+
+
+Roll a D6 to determine how many gold coins the Merchant would get for the item.
+
+
+  D6     Gold coins
+  1-2     Half the item&apos;s basic price
+  3-4     The item&apos;s full basic price
+  5-6     Full plus half the item&apos;s basic price
+
+
+Note that the Merchant may decide whether he wants to sell the item for that price or if he wants to try again after the next battle.
+
+
+This can be combined with the wholesale skill to sell up to D3+1 items each game.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="b89b-3982-9632-7e6c" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <sharedRules>

--- a/Middenheim_Mercinaries.cat
+++ b/Middenheim_Mercinaries.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="51919a76-f868-1581-224f-24394fbb0d64" name="Middenheimers (1a)" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="51919a76-f868-1581-224f-24394fbb0d64" name="Middenheimers (1a)" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Champion" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -1656,6 +1656,24 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="49f2-d30a-9e0f-1349" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3b17-5dd4-d4af-2fc2" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="b6e0-8e77-aaaf-82d8-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="b6e0-8e77-aaaf-82d8-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Middenheim Strength" id="e699-6203-2ba3-37f1" hidden="false">
+          <description>The men of Middenheim are famous for their physical prowess.
+To represent their advantage in size and bulk, the Champions and Captains of a Middenheim warband start with Strength 4 instead of Strength 3.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="6b8c-9344-5ef9-b163" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Miragleans.cat
+++ b/Miragleans.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6805-ff0e-9061-8cb6" name="Miragleans (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6805-ff0e-9061-8cb6" name="Miragleans (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="e87b-f686-aa1d-8236" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -164,7 +164,7 @@
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="6f44-6339-1db9-868" collective="false" targetId="317e-6c1f-20c6-7549" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="75bf-e5bb-879f-d29d" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="20a-c1d3-e038-5054" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="ddf9-a58-62cc-4af1" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="ddf9-a58-62cc-4af1" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -461,7 +461,7 @@
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="7770-eab5-e8e1-e5e4" collective="false" targetId="317e-6c1f-20c6-7549" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="d1dd-d405-ac19-3044" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="866c-2e06-3ae-6202" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="703d-8f8d-7a17-f1f" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="703d-8f8d-7a17-f1f" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -794,7 +794,7 @@
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="28d2-d47d-56f4-78d4" collective="false" targetId="317e-6c1f-20c6-7549" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="2417-4470-7c63-1e9c" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="6631-b28a-f6d-81de" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="940e-209e-60dc-5ce9" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="940e-209e-60dc-5ce9" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1167,7 +1167,7 @@
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="272-f73c-af87-9bd5" collective="false" targetId="317e-6c1f-20c6-7549" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="dace-8b86-9b8c-dd11" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="dace-8b86-9b8c-dd11" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1594,7 +1594,7 @@
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="823a-b00e-4d13-9aa8" collective="false" targetId="317e-6c1f-20c6-7549" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="ee6e-8dc6-ab2d-c6e6" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="ee6e-8dc6-ab2d-c6e6" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2032,7 +2032,7 @@ The Duellist counts as using a shield in close combat.</description>
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Marksman Equipment" hidden="false" id="5e98-8eb6-b609-dc61" collective="false" targetId="cf38-53f6-cf18-c5bc" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="22f2-318a-15f9-35c4" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="22f2-318a-15f9-35c4" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2319,7 +2319,7 @@ The Duellist counts as using a shield in close combat.</description>
         <categoryLink name="Stash" hidden="false" id="72c1-e311-6bac-1104" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="6db3-c985-1820-8831" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="6db3-c985-1820-8831" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="4ac2-b09e-6fde-c75e" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="a746-32b2-74b4-9c21" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2327,6 +2327,53 @@ The Duellist counts as using a shield in close combat.</description>
         <cost name="pts" hidden="false" id="32a8-155c-5708-7b9e" typeId="points" value="0"/>
         <cost name="Warband Rating" hidden="false" id="6029-4e28-70db-8492" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="0ce7-2ce9-dd01-c81e" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="d1e3-6c96-88db-5c1d" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="c3d3-978d-4c5b-9239-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="c3d3-978d-4c5b-9239-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hired Swords" id="3adb-c42f-b716-7457" hidden="false">
+          <description>A Tilean warband can use any Hired Sword available to the Mercenary warbands including the following
+
+
+ - Shadow Warrior
+ - Big Game Hunter
+ - Expert Marksman
+
+
+Unless noted otherwise, Hired Swords cannot benefit from individual city-state rules given to each warband.</description>
+        </rule>
+        <rule name="Crossbowmen" id="6ad1-f6e2-76b5-7d9e" hidden="false">
+          <description>The Miragleans are deadly accurate with the city’s official weapon, the crossbow (all variants).
+
+
+Therefore Miraglean Heroes have a +1 to hit when using crossbows only.
+
+
+Marksmen get a +1 to hit with any missile weapon they use (this is
+included in the marksmen’s profile).</description>
+        </rule>
+        <rule name="Hate Rats" id="511d-3f64-1493-934b" hidden="false">
+          <description>All Miragleans have a deep-seated hatred toward Skaven.
+
+
+This dates back to the red pox outbreak of 1812 when three quarters of the population of the city perished.
+
+
+When fighting Skaven a Miraglean warband will be affected by the rules for Hatred towards them.
+
+
+Hired swords and Dramatis Personae are not affected by the Hatred rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="3548-ea66-b3de-c288" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>
@@ -2371,7 +2418,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="4321-9552-9e67-c046" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="a106-e801-71b4-4509" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="f144-e282-6098-53ab" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="f144-e282-6098-53ab" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -2385,7 +2432,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
             <entryLink import="true" name="Spear" hidden="false" id="a8b-4b10-4c4a-a018" collective="false" targetId="005e-e397-8108-f198" type="selectionEntry"/>
             <entryLink import="true" name="Double Handed Weapon" hidden="false" id="8d06-cac3-d3a-79a3" type="selectionEntry" targetId="a0a1-b311-e3aa-6c3b"/>
             <entryLink import="true" name="Halberd" hidden="false" id="ed55-9bed-e8f5-fd06" type="selectionEntry" targetId="3c52-9e92-25ec-1939"/>
-            <entryLink import="true" name="Unknown" hidden="false" id="97a1-42e-7540-2622" type="selectionEntry" targetId="68ec-2a33-6ca8-d146"/>
+            <entryLink import="true" name="Pike" hidden="false" id="97a1-42e-7540-2622" type="selectionEntry" targetId="68ec-2a33-6ca8-d146"/>
             <entryLink import="true" name="Morning Star" hidden="false" id="d9d5-db08-484a-b964" type="selectionEntry" targetId="d5f3-1906-da91-4e8f"/>
             <entryLink import="true" name="Rapier" hidden="false" id="871-c437-6212-437f" type="selectionEntry" targetId="1cad-3ea5-f379-1040"/>
           </entryLinks>
@@ -2403,7 +2450,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="21f3-ef18-d13e-1c1e" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="d1ed-b283-5127-8da7" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="5d7b-f240-94ff-fcf1" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="5d7b-f240-94ff-fcf1" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
             <entryLink import="true" name="Bow" hidden="false" id="1f8a-630-500-da89" type="selectionEntry" targetId="311a-bf3f-67ff-46e7"/>
             <entryLink import="true" name="Crossbow" hidden="false" id="2964-c0fb-ab98-3639" type="selectionEntry" targetId="38cc-bc0b-7f19-8039"/>
           </entryLinks>
@@ -2413,7 +2460,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="5900-7eeb-83d-fc66" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="c9aa-56b1-e244-4a6" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="c9aa-56b1-e244-4a6" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="52e0-26ac-6286-50c5" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="86f4-988e-752-617f" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="ae7-f8f2-f626-2e22" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
@@ -2427,7 +2474,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="f712-7466-640d-f8d2" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="2cf8-5ea8-65dc-6b85" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="399b-9041-82fb-4e5a" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="399b-9041-82fb-4e5a" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -2453,7 +2500,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="e66d-47c3-6eb0-20c2" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="dd1e-2d6b-9e3a-4157" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="3090-e6af-a11-ad2b" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="3090-e6af-a11-ad2b" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
             <entryLink import="true" name="Longbow" hidden="false" id="816b-b252-17a2-fcd9" type="selectionEntry" targetId="afa2-2d5c-54dd-d435"/>
             <entryLink import="true" name="Crossbow" hidden="false" id="7aee-fd81-fa84-2ee" type="selectionEntry" targetId="38cc-bc0b-7f19-8039"/>
             <entryLink import="true" name="Handgun" hidden="false" id="4698-1515-9c8f-1fc4" type="selectionEntry" targetId="7f5a-d04d-153d-d334"/>
@@ -2465,7 +2512,7 @@ Unless noted otherwise, Hired Swords cannot benefit from individual city-state 
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="b455-9f33-66f8-360" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="cc96-988-d793-5b1e" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="cc96-988-d793-5b1e" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="d925-7125-970f-d4c7" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
         </selectionEntryGroup>

--- a/Mootlanders.cat
+++ b/Mootlanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="3ce7-ad0a-f74d-9c48" name="Mootlanders (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="3ce7-ad0a-f74d-9c48" name="Mootlanders (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <rules>
     <rule name="Weak constitution" hidden="false" id="dd88-dc67-8282-9124">
       <description>Halflings are very weak and puny and even the lightest of blows tends to knock them senseless.
@@ -1917,6 +1917,24 @@ Halfling thieves always have a -1 to hit modifier when being shot at, this add
         <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="0258-6d1d-8b01-5d74" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="cf5b-fea5-b464-600e" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="9706-371b-f774-1992-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="9706-371b-f774-1992-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Weak constitution" id="b1bd-7dba-782b-c520" hidden="false">
+          <description>Halflings are very weak and puny and even the lightest of blows tends to knock them senseless.
+When rolling for a Halfling’s injury, treat a roll of a 2 as ‘stunned’.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="a3ca-e25f-8d89-0c05" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="62b7-88e3-5eeb-8d7c" targetId="e020-c282-277b-b173"/>
@@ -1936,7 +1954,7 @@ Halfling thieves always have a -1 to hit modifier when being shot at, this add
               </modifiers>
             </entryLink>
             <entryLink import="true" name="Free Dagger" hidden="false" id="6615-9a21-6075-65ec" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="21ad-debc-1b9d-d4d4" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="21ad-debc-1b9d-d4d4" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Staff" field="name">
                   <conditions>
@@ -2005,7 +2023,7 @@ Halfling thieves always have a -1 to hit modifier when being shot at, this add
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="e78b-bf88-f679-b22f" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="5e5-b5b4-f0b6-dff0" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="5e5-b5b4-f0b6-dff0" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="53c3-ad36-caef-a6e2" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Cooking Pot Helmet" hidden="true" id="9ae4-3c10-9b7a-d86c" type="selectionEntry" targetId="e958-4b33-a85d-664b">
               <modifiers>

--- a/Mordheim.gst
+++ b/Mordheim.gst
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="9481a749-7900-614b-1695-bdc2899069c1" name="Mordheim" revision="16" battleScribeVersion="2.03" authorName="Uncle Mel" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
+<gameSystem id="9481a749-7900-614b-1695-bdc2899069c1" name="Mordheim" revision="17" battleScribeVersion="2.03" authorName="Uncle Mel" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
   <readme>If a Henchmen is promoted, Duplicate the henchmen group, remove 1 from the original group and set the promoted henchmen to 1 model. Battlescribe doesn&apos;t support splitting groups or dynamically changing categories</readme>
   <publications>
     <publication id="ff7c-2cb8-2105-563f" name="GitHub" publisherUrl="https://github.com/BSData/mordheim"/>
   </publications>
   <costTypes>
-    <costType id="points" name=" gc" defaultCostLimit="0" hidden="false"/>
+    <costType id="points" name=" gc" defaultCostLimit="-1" hidden="false"/>
     <costType id="wb-rating" name=" Warband Rating" defaultCostLimit="-1" hidden="false"/>
   </costTypes>
   <profileTypes>
@@ -59,7 +59,7 @@
   <forceEntries>
     <forceEntry id="7451d7da-3cc0-0299-775b-2f48162a731d" name="Warband" hidden="false" sortIndex="1">
       <categoryLinks>
-        <categoryLink name="Configuration" hidden="false" id="5d45-3d8d-79db-5458" targetId="4852-c4cb-82b0-b7fa" type="categoryEntry"/>
+        <categoryLink name="Configuration" hidden="false" id="5d45-3d8d-79db-5458" targetId="4852-c4cb-82b0-b7fa"/>
         <categoryLink id="7451d7da-3cc0-0299-775b-2f48162a731d-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" name="Heroes" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>

--- a/Night Goblins.cat
+++ b/Night Goblins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="8ae8-558c-e115-6668" name="Night Goblins (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="8ae8-558c-e115-6668" name="Night Goblins (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="aa51-11f1-7d42-1535" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -12,8 +12,7 @@
 
 
 This only affects Night Goblins, not any other models in the warband.
-Fanatics are so out of their skull that they are not affected.
-</description>
+Fanatics are so out of their skull that they are not affected.</description>
     </rule>
     <rule name="Fear Elves" id="7908-b29f-1079-a75c" hidden="false">
       <description>Night Goblins are terrified of the Elven race.
@@ -45,7 +44,7 @@ Once the model loses Frenzy, due to being knocked down or stunned, it will be e
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="ab43-2e28-36ba-b5a" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="c3b4-b098-5821-9505" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="74d6-4c25-f9df-3afc" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="74d6-4c25-f9df-3afc" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Club" field="name"/>
               </modifiers>
@@ -71,7 +70,7 @@ Once the model loses Frenzy, due to being knocked down or stunned, it will be e
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="b8a0-63c4-272c-c90c" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="4718-a786-859b-1925" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="4718-a786-859b-1925" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="4b6f-ce90-fc1b-b266" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="2"/>
             <entryLink import="true" name="Helmet" hidden="false" id="7312-be1d-d04f-e75a" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2" sortIndex="3"/>
           </entryLinks>
@@ -142,7 +141,7 @@ Once the model loses Frenzy, due to being knocked down or stunned, it will be e
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="45ec-f795-586b-82bd" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="4963-f1b2-494b-88a0" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="91ee-3a49-29f0-de69" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="91ee-3a49-29f0-de69" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Club" field="name"/>
               </modifiers>
@@ -164,7 +163,7 @@ Once the model loses Frenzy, due to being knocked down or stunned, it will be e
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="9d79-401d-d67d-ebd2" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="440f-2c17-8de5-cc54" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="440f-2c17-8de5-cc54" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="caaa-dd5a-fc1a-62bc" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="2"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -3485,6 +3484,50 @@ Trolls do not gain experience.</description>
           </constraints>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="b53a-ed07-c4ac-5aea" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="90da-fb79-5e60-8968" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="9f31-b90d-8c80-c723-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="9f31-b90d-8c80-c723-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Distasteful Company" id="fd02-78a6-f64b-6344" hidden="false">
+          <description>Many Hired Swords refuse to work for Night Goblins, they know that the backstabbing &apos;lil gits are likely to turn on them.
+
+
+Night Goblins may only hire Pit Fighters, Ogre Bodyguards, Warlocks, Witches, plus any Hired Sword that specifically states they work with Orcs or Goblins.</description>
+        </rule>
+        <rule name="Fear Elves" id="9ebc-dd8a-cee7-433f" hidden="false">
+          <description>Night Goblins are terrified of the Elven race.
+
+
+This only affects Night Goblins, not any other models in the warband.
+Fanatics are so out of their skull that they are not affected.</description>
+        </rule>
+        <rule name="Hate Stunties" id="4aa5-b028-fd11-1fdc" hidden="false">
+          <description>Night Goblins are subject to hatred towards Dwarfs.
+
+
+This only affects Night Goblins, not any other models in the warband.
+Fanatics are so out of their skull that they are not affected.</description>
+        </rule>
+        <rule name="Mad Cap Masters" id="0e7b-6167-f5dd-539f" hidden="false">
+          <description>Night Goblins consume so much dangerous fungi they can ignore some of the permanent side effects of Mad Cap Mushrooms, provided they have a constant supply.
+
+
+Night Goblins affected by Mad Cap overuse may ignore the resulting Stupidity, but only while under the effect of more Mad Caps.
+
+
+Once the model loses Frenzy, due to being knocked down or stunned, it will be effected by Stupidity as normal.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="c623-2461-8a5f-32fb" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+        <infoLink name="Animosity" id="2b59-de69-60cd-8230" hidden="false" type="rule" targetId="c214-2ad0-8f27-7328"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Norse Explorers.cat
+++ b/Norse Explorers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="b854-4934-9cad-dcb0" name="Norse Explorers (1b) (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="b854-4934-9cad-dcb0" name="Norse Explorers (1b) (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="950e-3bb9-3296-b6c4" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -10,7 +10,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="8cae-f894-2959-5b14" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="b611-c00e-b099-8301" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="688c-a1cc-62e7-9dbe" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="688c-a1cc-62e7-9dbe" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -49,7 +49,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="fd39-6530-b6f-7934" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="b44a-b983-ee7d-6833" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="b44a-b983-ee7d-6833" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="d650-96fc-7be8-fa10" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="4353-13c0-411b-564a" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
@@ -69,7 +69,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="5e94-c694-d378-4640" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="12a4-99df-dc0-65f1" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="9f24-682b-8c92-1fed" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="9f24-682b-8c92-1fed" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -97,7 +97,7 @@
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="313-6da6-2ba0-5d3a" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Bow" hidden="false" id="d009-5503-a5a9-bf8b" type="selectionEntry" targetId="311a-bf3f-67ff-46e7"/>
-            <entryLink import="true" name="Javelins/Harpoons" hidden="false" id="5c2a-60bc-8663-fe4a" type="selectionEntry" targetId="ece5-fffa-8dd8-94dc">
+            <entryLink import="true" name="Javelins" hidden="false" id="5c2a-60bc-8663-fe4a" type="selectionEntry" targetId="ece5-fffa-8dd8-94dc">
               <modifiers>
                 <modifier type="set" value="Javelins" field="name"/>
               </modifiers>
@@ -121,7 +121,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="fc7a-2f47-b11f-800d" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="da98-d3b0-76c6-ccd2" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="208-42ad-aa91-1ad2" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="208-42ad-aa91-1ad2" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer" field="name"/>
               </modifiers>
@@ -160,7 +160,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="d882-5406-800f-a443" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="9dbb-f5-e811-5881" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="9dbb-f5-e811-5881" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="26d8-986c-a983-7dac" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="4f29-6096-fc37-25da" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
@@ -481,7 +481,7 @@ No enemy may parry an attack made by this hero because it strikes with such grea
         <entryLink import="true" name="Hero Equipment" hidden="false" id="2fb8-c56f-5fc3-b456" collective="false" targetId="e434-139e-28e6-49e1" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="5061-724-c2ff-3442" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="f28a-19b4-6aaa-474a" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="23af-91b8-2ba5-83cf" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="23af-91b8-2ba5-83cf" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -779,7 +779,7 @@ No enemy may parry an attack made by this hero because it strikes with such grea
         </entryLink>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="fb40-8624-af02-7665" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="4b37-1726-f929-14d6" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="1f7c-1393-8b91-434c" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="1f7c-1393-8b91-434c" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1122,7 +1122,7 @@ too feral and uncontrolled to become the leader of the warband.</description>
         <entryLink import="true" name="Hero Equipment" hidden="false" id="cd03-690d-ac5a-7fa6" collective="false" targetId="e434-139e-28e6-49e1" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="181e-fdc2-50ce-372b" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="f59d-dff0-62e-f87a" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="838a-bdb5-4d66-962" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="838a-bdb5-4d66-962" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1500,7 +1500,7 @@ too feral and uncontrolled to become the leader of the warband.</description>
         <entryLink import="true" name="Hero Equipment" hidden="false" id="5bac-7794-3a55-3e68" collective="false" targetId="e434-139e-28e6-49e1" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="4737-e807-c82a-57fa" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="bfb1-6e9c-94b8-b2d3" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="a49-ff2e-4e4f-125f" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="a49-ff2e-4e4f-125f" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1829,7 +1829,7 @@ too feral and uncontrolled to become the leader of the warband.</description>
         </entryLink>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="4837-ef70-13b4-3ccb" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="ec21-68b5-4b26-b3e4" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="1c14-3f1a-7d89-b504" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="1c14-3f1a-7d89-b504" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2183,7 +2183,7 @@ too feral and uncontrolled to become the leader of the warband.</description>
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Hunter Equipment" hidden="false" id="a2b-bf39-4f1c-e5ae" collective="false" targetId="48b4-d4b8-2d71-24dc" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="14b2-4013-7364-3d77" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="14b2-4013-7364-3d77" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2782,7 +2782,7 @@ In the event that no Wulfen (Ulfwerenar) is included in the warband due to a de
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Henchman Equipment" hidden="false" id="bc49-2c1a-7dc5-14f7" collective="false" targetId="5f97-4cb5-5f38-88f0" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="a2e4-24a0-a7a4-9265" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="a2e4-24a0-a7a4-9265" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -3056,6 +3056,18 @@ In the event that no Wulfen (Ulfwerenar) is included in the warband due to a de
         <cost name="pts" hidden="false" id="d7b7-e56f-34d5-4ca" typeId="points" value="25"/>
         <cost name="Warband Rating" hidden="false" id="f2e9-c9af-b372-bf49" typeId="wb-rating" value="5"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="1811-7ecb-b161-28e4" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="a2d3-1b40-1b90-c0ae" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="b1c4-abda-5d44-4bef-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="b1c4-abda-5d44-4bef-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="d925-5085-e08a-a4a2" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Ork_Mob.cat
+++ b/Ork_Mob.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8b66f7c3-fdd7-fcea-eb91-086959d72140" name="Orc Mob (1a)" revision="19" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="8b66f7c3-fdd7-fcea-eb91-086959d72140" name="Orc Mob (1a)" revision="20" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="0094-a0e7-9fc9-5aa2" name="Ork Mob Rules" shortName="Broheim Rules (1a)" publisher="https://broheim.net/downloads/warbands/official/Orc%20Mob.pdf" publisherUrl="https://broheim.net/downloads/warbands/official/Orc%20Mob.pdf"/>
   </publications>
@@ -1591,6 +1591,50 @@ Trolls do not gain experience.</description>
         <cost name="pts" typeId="points" value="200"/>
         <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="ff7d-ad80-6e26-2253" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3a6b-fbdd-01c2-13f1" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="8ee3-47f1-4d21-6d51-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="8ee3-47f1-4d21-6d51-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Animosity" id="3059-3d65-2f99-c14c" hidden="false" page="0">
+          <description>At the start of the Orc player’s turn, roll a D6 for each Henchman who is either an Orc or a Goblin and not in Hand to Hand Combat.
+
+Roll on table below if 1 is rolled. 
+
+1 “I ’Erd Dat!”
+If there is a friendly Orc or Goblin Henchman or Hired Sword within charge reach (if there are multiple targets within reach, choose the one nearest to the mad model), the warrior must immediately charge and fight a round of hand-to-hand combat against the Target.
+At the end of this round of combat, the models will immediately move 1&quot; apart and no longer count as being in close combat.
+If there are no friendly Orc or Goblin Henchmen or Hired Swords within charge reach, and the warrior is armed with a missile weapon, he immediately takes a shot at the nearest friendly Orc or Goblin Henchman or Hired Sword.
+If none of the above applies, or if the nearest friendly model is an Orc Hero, the warrior behaves as if a 2-5 had been rolled on this chart.
+In any case, the warrior in question may take no other action this turn, though he may defend himself if attacked in hand-to-hand combat.
+
+2-5 “Wud Yoo Say?” 
+The warrior is fairly certain he heard an offensive sound from the nearest friendly Orc or Goblin, but he’s not quite sure.
+He spends the turn hurling insults at his mate.
+He may do nothing else this turn, though he may defend himself if attacked in hand-to-hand combat.
+
+6. “I’ll Show Yer!” 
+The warrior imagines that his mates are laughing about him behind his back and calling him silly names.
+To show them up he decides that he’ll be the first one to the scrap! 
+This model must move as quickly as possible towards the nearest enemy model, charging into combat if possible.
+If there are no enemy models within sight, the Orc or Goblin warrior may make a normal move immediately.
+This move is in addition to his regular move in the Movement phase, so he may therefore move twice in a single turn if you wish.
+If the extra move takes the Orc or Goblin warrior within charge reach of an enemy model, the warrior must charge into close combat during his regular movement.</description>
+        </rule>
+        <rule name="Distasteful Company" id="54b0-c32f-fe70-807e" hidden="false" page="0">
+          <description>Many Hired Swords refuse to work for Orcs, as they know that Orcs are just as likely to eat them as fight alongside them.
+Orcs may only hire the following Hired Swords: 
+  Pit Fighters, Ogre Bodyguards or Warlocks.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="a7c1-9a8f-0986-4326" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Ostermarkers.cat
+++ b/Ostermarkers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="c315-31da-1718-4dde" name="Ostermarkers (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="c315-31da-1718-4dde" name="Ostermarkers (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="4" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="70d7-f26c-2d0f-b6a1" targetId="e020-c282-277b-b173"/>
     <catalogueLink type="catalogue" name="Characters" id="340f-935f-33ea-76d8" targetId="9bf78c55-7dba-4a44-90ce-10ed57d8b3a1"/>
@@ -11,7 +11,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="aba3-222a-8137-8452" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="a44e-b24f-7dfa-29af" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="f2e-9eb8-5190-ffe0" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="f2e-9eb8-5190-ffe0" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -41,7 +41,7 @@
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="184c-1326-5118-cfdd" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="1752-23fa-b273-99e9" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="12f1-830d-fd58-72b9" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="12f1-830d-fd58-72b9" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
@@ -55,11 +55,11 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="7a2-76f7-f12e-45d2" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="e937-a2cf-248a-8b77" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="e937-a2cf-248a-8b77" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="7aa1-a8bf-5a46-6715" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="116b-b40e-e045-9b20" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="c5dd-4e7b-cffb-5b39" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="c16e-7ca0-4779-72a4" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="c16e-7ca0-4779-72a4" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -70,7 +70,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="4314-29b4-617-3259" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="882e-afcd-d608-dd36" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="85fe-c2ef-fa35-f323" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="85fe-c2ef-fa35-f323" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -109,7 +109,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="ebc9-fe89-e2ba-7b29" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="e18b-e0cb-466d-72ba" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="e18b-e0cb-466d-72ba" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="2ea1-1376-225c-cc50" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Shield" hidden="false" id="ea11-de24-1294-ced4" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
           </entryLinks>
@@ -278,7 +278,7 @@
         <entryLink import="true" name="Mercenary Equipment" hidden="false" id="11dc-fc9a-b1ba-4e16" collective="false" targetId="637c-f7df-b54a-315f" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="14b7-b03d-738e-652c" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="7de0-ddf8-7037-dcc1" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="290e-afc9-5082-4d84" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="290e-afc9-5082-4d84" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -575,7 +575,7 @@
         <entryLink import="true" name="Mercenary Equipment" hidden="false" id="1e2f-3c18-e1a1-3085" collective="false" targetId="637c-f7df-b54a-315f" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="e18b-ed48-8bd2-1b5d" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="2d34-2b66-e6eb-5188" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="e824-250a-8848-3d0a" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="e824-250a-8848-3d0a" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -908,7 +908,7 @@
         <entryLink import="true" name="Mercenary Equipment" hidden="false" id="409-6ca-9222-a1f2" collective="false" targetId="637c-f7df-b54a-315f" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="7540-9f50-a08a-dbc2" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="ce57-73e3-4bed-2f5" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="f7cc-56d7-1518-e188" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="f7cc-56d7-1518-e188" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1298,7 +1298,7 @@
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Mercenary Equipment" hidden="false" id="b334-7665-275b-3998" collective="false" targetId="637c-f7df-b54a-315f" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="bf93-2555-e935-9ba9" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="bf93-2555-e935-9ba9" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1742,7 +1742,7 @@
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Marksman Equipment" hidden="false" id="5be8-7db9-a6b3-c668" collective="false" targetId="af6d-b84d-99cf-d72c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="6a82-47d6-706e-ecbe" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="6a82-47d6-706e-ecbe" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2189,7 +2189,7 @@
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Mercenary Equipment" hidden="false" id="3973-c515-49a1-cda7" collective="false" targetId="637c-f7df-b54a-315f" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="688b-6562-f096-116b" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="688b-6562-f096-116b" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2475,9 +2475,21 @@ Note that this only applies when they are armed with normal swords, and not wit
         <constraint type="max" value="5" field="selections" scope="roster" shared="true" id="c34e-13a4-4deb-f606" includeChildSelections="true"/>
       </constraints>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="5da8-233f-68ac-e1d3" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="28f2-2c23-a154-a188" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="e4ab-5806-d265-5cdf-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="e4ab-5806-d265-5cdf-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="4691-f58c-53ce-7ab5" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink import="true" name="Priest of Morr" hidden="false" id="1fb4-ddcb-1ae7-ec" type="selectionEntry" targetId="d99a-5b47-80f6-75ad">
+    <entryLink import="true" name="Priest of Morr (1b)" hidden="false" id="1fb4-ddcb-1ae7-ec" type="selectionEntry" targetId="d99a-5b47-80f6-75ad">
       <categoryLinks>
         <categoryLink targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" id="388b-17d0-47f8-b7c8" primary="true" name="Heroes"/>
       </categoryLinks>

--- a/Ostlanders.cat
+++ b/Ostlanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="05ad-b0d8-77a8-2572" name="Ostlanders (1a)" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="05ad-b0d8-77a8-2572" name="Ostlanders (1a)" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue" page="0">
   <publications>
     <publication id="42ce-e25d-7713-b46b" name="Ostlanders Rules" shortName="Ostlanders" publisher="https://broheim.net/downloads/warbands/official/Ostlanders.pdf" publisherUrl="https://broheim.net/downloads/warbands/official/Ostlanders.pdf"/>
   </publications>
@@ -1724,6 +1724,24 @@ Ogres only gain advances at half the rate of everyone else (ie, they must accrue
           </modifiers>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="33c2-3f65-525e-fa50">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="e4b1-213e-dbe3-c4a1" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="23b9-caf4-7d80-2153-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="23b9-caf4-7d80-2153-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Self Sufficient" id="6543-5e20-298e-29fd" hidden="false">
+          <description>The men of Ostland have no desire to give their hard-earned gold to outsiders.
+As a result they can never hire any Mercenaries except for Ogres (who are not an uncommon sight in Ostland).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="d0b0-c011-1d0c-5c5b" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Outlaws of Stirwood.cat
+++ b/Outlaws of Stirwood.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="5ef4-8dba-4608-5227" name="Outlaws of Stirwood (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="5ef4-8dba-4608-5227" name="Outlaws of Stirwood (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="478e-d9ce-d69f-2496" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -10,7 +10,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="9a50-9479-9a22-dd9d" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="49c9-b738-b4aa-d3b2" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="4244-95fb-bd5e-e2db" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="4244-95fb-bd5e-e2db" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Staff, Club, Mace" field="name"/>
               </modifiers>
@@ -69,7 +69,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="f031-1852-790a-8382" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="true" id="d106-bd22-82ae-3d5c" type="selectionEntry" targetId="3d2a-426a-c350-2a03">
+            <entryLink import="true" name="Light Armour" hidden="true" id="d106-bd22-82ae-3d5c" type="selectionEntry" targetId="3d2a-426a-c350-2a03">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -447,7 +447,7 @@ The only exception to this is the Cleric who may choose to carry a bow, but is
         <entryLink import="true" name="Outlaws Equipment" hidden="false" id="1c49-2534-9d2c-32db" collective="false" targetId="b784-3696-a861-1e85" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="fce3-6d2f-9751-a3fa" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="1db4-9f93-58c4-88fb" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="8973-27e9-1232-9e7b" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="8973-27e9-1232-9e7b" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -744,7 +744,7 @@ The only exception to this is the Cleric who may choose to carry a bow, but is
         <entryLink import="true" name="Outlaws Equipment" hidden="false" id="e328-deb7-3989-a416" collective="false" targetId="b784-3696-a861-1e85" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="fe27-4a41-f535-55f8" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="da8a-f9ce-a87a-ae84" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="c356-dd21-74b3-ce87" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="c356-dd21-74b3-ce87" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1092,7 +1092,7 @@ The only exception to this is the Cleric who may choose to carry a bow, but is
         <entryLink import="true" name="Outlaws Equipment" hidden="false" id="ffd-5605-3a17-dfce" collective="false" targetId="b784-3696-a861-1e85" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="f79b-1fc9-90c7-7625" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="81a2-a31e-870d-3d06" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="5dd1-2c3e-3ee6-7664" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="5dd1-2c3e-3ee6-7664" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1446,7 +1446,7 @@ As with a Witch-Hunter’s Warrior Priest, he is also subject to some of the r
         <entryLink import="true" name="Outlaws Equipment" hidden="false" id="d5cd-4be6-35e5-45c0" collective="false" targetId="b784-3696-a861-1e85" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="aae-ecf9-7fb6-5c20" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="8649-ab46-f699-cb9b" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="5a29-bd77-b5d4-e9eb" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="5a29-bd77-b5d4-e9eb" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1831,7 +1831,7 @@ As with a Witch-Hunter’s Warrior Priest, he is also subject to some of the r
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Outlaws Equipment" hidden="false" id="ea4c-2f70-ecd3-4129" collective="false" targetId="b784-3696-a861-1e85" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="f031-1ae4-ea62-8ed2" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="f031-1ae4-ea62-8ed2" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2273,7 +2273,7 @@ As with a Witch-Hunter’s Warrior Priest, he is also subject to some of the r
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Outlaws Equipment" hidden="false" id="9d41-b5c4-609d-33d0" collective="false" targetId="b784-3696-a861-1e85" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="5fa1-8ecf-db4a-1f28" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="5fa1-8ecf-db4a-1f28" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2557,7 +2557,7 @@ As with a Witch-Hunter’s Warrior Priest, he is also subject to some of the r
         <categoryLink name="Stash" hidden="false" id="d3ca-db06-de2a-4b9d" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="3c47-5b62-6644-23cd" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="3c47-5b62-6644-23cd" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="d8ed-7706-ff3b-6dbd" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="440b-ea84-997c-b68a" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2565,6 +2565,39 @@ As with a Witch-Hunter’s Warrior Priest, he is also subject to some of the r
         <cost name="pts" id="544f-9c67-5b87-8a96" hidden="false" typeId="points" value="0"/>
         <cost name="Warband Rating" id="7592-aa12-8d8d-91ec" hidden="false" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="d6f6-ca14-032d-dcbc" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="bfde-f53e-f138-a990" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="eb19-952b-fb8e-5b77-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="eb19-952b-fb8e-5b77-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hired Swords" id="d915-a889-d026-14a7" hidden="false">
+          <description>The following Hired Swords are not available to the Outlaws: 
+  Bounty Hunter,
+  Wolf-Priest of Ulric,
+  Norse Shaman, 
+  Dark Elf Assassin.</description>
+        </rule>
+        <rule name="Bow required" id="e7b0-48c9-767d-be6e" hidden="false">
+          <description>All warriors in an Outlaws warband may be equipped with only one missile weapon at any time.
+
+
+All warriors must carry a type of bow, but not crossbows, as part of their equipment. So, even if an Outlaw acquires skills that allow him to use additional ballistic weaponry, he cannot do so.
+
+
+The only exception to this is the Cleric who may choose to carry a bow, but is not compelled to do so.</description>
+        </rule>
+        <rule name="Cleric" id="2d41-e8bc-67a0-64ee" hidden="false">
+          <description>Your warband may include up to one Cleric, but he can only be taken instead of either a Champion or a Petty Thief.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="cb6c-2c07-b9d9-052f" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Pirates.cat
+++ b/Pirates.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6805-5465-81dd-a433" name="Pirates (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6805-5465-81dd-a433" name="Pirates (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="cf9d-16eb-44a7-1fbe" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -2576,8 +2576,8 @@ They may re-roll failed Initiative tests Leaping over Gaps, Jumping Down, and 
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Characteristic Increases (only captured models)" hidden="false" id="e0cd-d130-5a6e-2699" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Skills (only captured models)" hidden="false" id="d0eb-a39-dbe2-3ce8" collective="false" targetId="df1f-9abb-8310-fb62" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Characteristic Increases" hidden="false" id="e0cd-d130-5a6e-2699" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Skills" hidden="false" id="d0eb-a39-dbe2-3ce8" collective="false" targetId="df1f-9abb-8310-fb62" type="selectionEntryGroup"/>
         <entryLink import="true" name="Swabbie Equipment" hidden="false" id="b06f-abdf-e1ab-ab49" collective="false" targetId="8da8-929b-1f85-db8d" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
@@ -2639,6 +2639,105 @@ Any Swabbies who are running away or have been taken out of action do not coun
         </modifier>
       </modifiers>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="523f-3b2d-8697-926b" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3c29-5108-85aa-267d" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="89e1-8370-5ad1-da43-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="89e1-8370-5ad1-da43-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Free Swabbies" id="7195-7e54-618c-48f1" hidden="false">
+          <description>In one-off games, a Pirate Warband starts with two Swabbies for free.</description>
+        </rule>
+        <rule name="Hired Swords" id="7c05-2b3a-f760-dd19" hidden="false">
+          <description>Unless noted otherwise, Pirate Warbands have the same access to Hired Swords &amp; any other items as for a regular human Mercenary Warband, and follow all the normal rules for them as well.
+
+
+They must however pay an additional +20 gc in upkeep if they have both Dwarfs and Elves together in the same warband (the ship is only so big, and the confines make them more irritable than usual!).</description>
+        </rule>
+        <rule name="Succession" id="e3ed-b743-c8c6-ca1b" hidden="false">
+          <description>If the Captain is killed, one of the Mates will take over in the same manner as a Champion taking over for a Mercenary warband.</description>
+        </rule>
+        <rule name="Swabbies" id="7d56-a78f-a49f-e1c9" hidden="false">
+          <description>Pirate warbands can ‘recruit’ new members to join the adventuresome life of a pirate, sometimes willingly but oftentimes more as an alternative to walking the plank! Only humans can be recruited in this manner though – not even the most bloodthirsty pirate would ever trust a Skaven or Beastman, and other races even though friendly to mankind would normally never follow a mere human into battle!
+
+
+The following special rules apply to certain situations in Mordheim game play:
+
+
+Kidnapped! Enemy human Heroes who after the game rolled up the Captured result (D66 rolls of 61 or 62) can be ‘offered’ one opportunity to join the pirate crew (usually at the point of a cutlass!).
+
+
+As an alternative to exchanging/ransoming the captured Hero back to their original Warband (or selling him to slavers), the Pirate Captain can instead add the captured enemy to the ship’s crew as follows.
+
+
+Both players roll 2D6, with the Pirate player adding the Captain’s Leadership and the enemy player adding the Leadership of the captured Hero.
+If either side won that game, it may add +1 to it’s score.
+
+
+
+If the Pirate player’s result is higher, the Hero renounces his old ways for the life of the high seas!
+She or he joins the Crew, either starting a new Crew group or joining an existing one if it has four models or less.
+There is no extra cost to add him to a group which has accumulated experience points, and any equipment or weapons he had are immediately sold off to buy him the proper weapons and armor to match his new unit in an even swap. 
+
+
+His skills and characteristics are changed to those of a starting Crewman, or to match those of his new crewmates if joining an existing group.
+
+
+Otherwise, the Hero has resisted the siren’s song of the sea, and is forced to become a Swabbie (see Swabbies below).
+
+
+He is stripped of his equipment and weapons; these are handed out as the player desires.
+
+
+He does retain any skills and keeps his original characteristics, but can only be re-armed with the weapons listed in the Swabbie equipment list.
+
+
+Enemy human Henchmen taken Out of Action during the game and then lost from their original Warband for good (a 1-2 was rolled for them post-game) also have a chance of joining up too!
+
+
+Roll another D6 for each: on a roll of 4+, the Pirates manage to drag them away or otherwise make off with their wounded bodies, and patch them up on the ship.
+
+
+The Pirate player can then test to see if they will join exactly as above, by both players rolling 2D6 and adding it to the Captain’s and the Henchman’s Leadership.
+
+
+This test can only be done if the Pirates win the game, so the Pirate player will always get a +1 to his roll.
+
+
+Hired Swords and Special Characters are too skilled to be taken off in this manner, and can never be recruited – they have their own agendas to pursue, and will ensure the pirate life is not part of those plans.
+
+
+Well now matey, have you ever considered pirating as a career?
+If the Pirates encounter Stragglers (result 44) or Prisoners (result 333) when Searching, there is a chance they may sign up to sail under the Jolly Roger. 
+
+
+Either of these options may be used instead of the regular options listed for these situations.
+
+
+If a Straggler is found, the Captain can try to convince him to join the crew by making a successful Leadership test.
+If passed, the Straggler joins as a Swabbie (he’s too unhinged even to become a member of the Crew!)
+
+
+If Prisoners are found, roll a D3 to determine how many are rescued.
+If the Captain passes a Leadership test (he must make a separate test for each one), the Prisoner eagerly joins his rescuers as a member of the Crew, either starting a new Crew group or joining an existing one if it has four models or less.
+If he is starting a new Crew group, he will start at the normal characteristics levels for a normal Crew member and at Zero Experience.
+
+
+There is no extra cost to add him to an existing group which has accumulated experience points, and his skills and characteristics match those of his new crewmates.
+The player must pay though to equip and arm the new Crewman as per his new unit.
+If the player cannot pay, the prisoner must join as a Swabbie.
+
+
+If the test is failed, the Prisoner isn’t quite so convinced of the worthiness of the sea dogs and is added as a Swabbie.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="6978-4fd4-22c0-23ee" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Pirate Equipment" id="7c3-bc18-ea97-5d07" hidden="false">
@@ -2647,7 +2746,7 @@ Any Swabbies who are running away or have been taken out of action do not coun
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="e69e-aea8-c691-8ed2" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="cf3a-a586-ea4b-c953" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="2f8c-34f4-149b-cd59" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="2f8c-34f4-149b-cd59" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -2688,12 +2787,12 @@ Any Swabbies who are running away or have been taken out of action do not coun
         <selectionEntryGroup name="Missile Weapons" id="b0be-a3ab-3278-9471" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="8a03-9fc-a28d-5896" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="59d5-d411-4ec2-37cf" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="59d5-d411-4ec2-37cf" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Belaying Pin" hidden="false" id="63b2-f5-70ef-90f6" type="selectionEntry" targetId="282e-5485-a38c-9f14"/>
+            <entryLink import="true" name="Belaying Pins" hidden="false" id="63b2-f5-70ef-90f6" type="selectionEntry" targetId="282e-5485-a38c-9f14"/>
             <entryLink import="true" name="Crossbow" hidden="false" id="1968-6686-75bb-46d5" type="selectionEntry" targetId="38cc-bc0b-7f19-8039"/>
           </entryLinks>
           <constraints>
@@ -2702,7 +2801,7 @@ Any Swabbies who are running away or have been taken out of action do not coun
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="970d-6f30-c5cd-9e0e" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="8833-8289-1496-f0fd" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="8833-8289-1496-f0fd" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="a26c-707c-75d7-ff07" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="d141-9e3c-b0ed-896e" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
             <entryLink import="true" name="Toughened Leathers" hidden="false" id="c276-52be-9a5b-ba61" type="selectionEntry" targetId="439f-1b4d-1579-14b"/>
@@ -2957,7 +3056,7 @@ Though only a small chest is found at the site, when opened it reveals 2+D3 sha
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="4101-f089-4ccc-3a8d" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="a4d2-fafe-2da9-9b31" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="533b-a83a-ade8-d575" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="533b-a83a-ade8-d575" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -2988,7 +3087,7 @@ Though only a small chest is found at the site, when opened it reveals 2+D3 sha
         </selectionEntryGroup>
         <selectionEntryGroup name="Missile Weapons" id="1160-2523-b21f-7f51" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Belaying Pin" hidden="false" id="5ec8-85b5-91ed-e5b2" type="selectionEntry" targetId="282e-5485-a38c-9f14"/>
+            <entryLink import="true" name="Belaying Pins" hidden="false" id="5ec8-85b5-91ed-e5b2" type="selectionEntry" targetId="282e-5485-a38c-9f14"/>
             <entryLink import="true" name="Bow" hidden="false" id="b6fb-62d8-fcd4-449f" type="selectionEntry" targetId="311a-bf3f-67ff-46e7"/>
           </entryLinks>
           <constraints>
@@ -3009,7 +3108,7 @@ Though only a small chest is found at the site, when opened it reveals 2+D3 sha
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="d8de-18e6-77b0-535b" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="bcb9-ce05-a41d-9e41" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="a5cb-8bc3-ceef-e92c" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="a5cb-8bc3-ceef-e92c" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -3039,7 +3138,7 @@ Though only a small chest is found at the site, when opened it reveals 2+D3 sha
         <selectionEntryGroup name="Missile Weapons" id="56dd-af48-9a38-c9f0" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="624f-9a1c-893f-6f0b" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="e328-efc8-41b7-1b61" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="e328-efc8-41b7-1b61" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
@@ -3054,7 +3153,7 @@ Though only a small chest is found at the site, when opened it reveals 2+D3 sha
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="15a9-7aab-a7c3-6db" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="fa5b-6dee-c631-5a03" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="fa5b-6dee-c631-5a03" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="7c6f-22f0-a9c4-a26e" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Toughened Leathers" hidden="false" id="1a7-ea2f-f54e-9b9f" type="selectionEntry" targetId="439f-1b4d-1579-14b"/>
           </entryLinks>
@@ -3507,7 +3606,7 @@ If he fails the test he remains in combat and must fight as normal in the follow
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="7763-971a-723d-899b" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="daa4-d050-f91c-abd3" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="233-662e-60a2-fdc9" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="233-662e-60a2-fdc9" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -3548,12 +3647,12 @@ If he fails the test he remains in combat and must fight as normal in the follow
         <selectionEntryGroup name="Missile Weapons" id="2b13-509e-777c-9cfd" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="577e-c005-d6b7-2b90" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="d0e-46ed-d48c-a626" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="d0e-46ed-d48c-a626" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Belaying Pin" hidden="false" id="8f99-9247-ae07-a74b" type="selectionEntry" targetId="282e-5485-a38c-9f14"/>
+            <entryLink import="true" name="Belaying Pins" hidden="false" id="8f99-9247-ae07-a74b" type="selectionEntry" targetId="282e-5485-a38c-9f14"/>
             <entryLink import="true" name="Crossbow" hidden="false" id="cc04-b235-d56b-7a1e" type="selectionEntry" targetId="38cc-bc0b-7f19-8039"/>
           </entryLinks>
           <constraints>
@@ -3562,7 +3661,7 @@ If he fails the test he remains in combat and must fight as normal in the follow
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="c032-7dba-8dee-5db4" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="4066-dd43-9d45-b963" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="4066-dd43-9d45-b963" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="1731-718d-77a-81b2" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="9eda-3168-c787-7b81" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
             <entryLink import="true" name="Toughened Leathers" hidden="false" id="e2c4-f821-c512-c52f" type="selectionEntry" targetId="439f-1b4d-1579-14b"/>
@@ -3958,7 +4057,7 @@ Pirates know to duck out of the way when they hear a Swivel Gun going off, and t
             </rule>
           </rules>
           <infoLinks>
-            <infoLink name="Ignores Armor" id="608f-4504-f06a-d259" hidden="false" type="rule" targetId="1f6d-8599-e2d3-1062"/>
+            <infoLink name="Ignores Armour" id="608f-4504-f06a-d259" hidden="false" type="rule" targetId="1f6d-8599-e2d3-1062"/>
           </infoLinks>
         </selectionEntry>
       </selectionEntries>

--- a/Pit Fighters.cat
+++ b/Pit Fighters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="36fc-7d97-ad53-330b" name="Pit Fighters (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="36fc-7d97-ad53-330b" name="Pit Fighters (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="64c-4c4-51a9-6bd6" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -70,7 +70,7 @@
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="c953-6f49-e3aa-6642" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" id="f513-6e9b-620-92d1" type="selectionEntry" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="d5d4-278d-4548-f9c2" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" id="d5d4-278d-4548-f9c2" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace, Hammer" field="name"/>
               </modifiers>
@@ -98,7 +98,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="c7df-64dc-f97-f259" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="89e3-e4fa-4ec6-8eae" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="89e3-e4fa-4ec6-8eae" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="fffa-7b5a-316c-542c" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
           <modifiers>
@@ -3506,6 +3506,98 @@ On a successful Initiative test it is considered a failed charge and the norma
       <constraints>
         <constraint type="max" value="7" field="selections" scope="roster" shared="true" id="2885-6f8e-a157-7d9" includeChildSelections="true"/>
       </constraints>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="8f7d-f36b-3cf2-6f2f" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="ca5a-fefd-a189-0cf7" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="b549-4511-644d-25da-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="b549-4511-644d-25da-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Free the Slaves!" id="37bc-f43e-b8a0-c17a" hidden="false">
+          <description>Pit Fighters hate all slavers.
+
+
+The Pit Fighters will never sell their captured opponents to the slavers.</description>
+        </rule>
+        <rule name="Hired Swords" id="a785-74f0-7c3a-f669" hidden="false">
+          <description>Pit Fighters may hire all Hired Swords available except for the Elf Ranger, who feels working with such dirty and brutish individuals would just not do!</description>
+        </rule>
+        <rule name="In the Pit!" id="153d-f37b-905c-e776" hidden="false">
+          <description>Pit Fighters who capture an opponent may decide to let him fight in the infamous fighting pits of Cutthroat’s Haven (use the rules that appeared earlier in this magazine).
+
+
+The Pit Fighter warband may decide to send in one or more of their own fighters to fight the captive, if the Pit Fighter wins he gains +2 Experience, the warband gets all the captive’s armor and weapons +50gc, if the Pit Fighter loses then roll to see whether he is dead or injured as normal (ignore all following results: Robbed, Captured, Hardened, Sold to the Pits and Survives against the Odds), he will not lose his armor or weapons, the captive will get the 50gc and the +2 Experience when he wins.
+
+
+If the captive wins, the audience decides whether he gains his freedom. Roll a D6 on a 4+ the audience raise their thumbs and he is free. 
+A 1-3 means he remains the Pit Fighters captive and may be fielded in the pits after future games.</description>
+        </rule>
+        <rule name="Weapons &amp; Armor" id="be0a-79b3-3da3-861f" hidden="false">
+          <description>Unlike other warbands that may chose which weapons and armor to equip their warriors with, Pit Fighters have to chose a specific fighting style which dictates their weapons and armor configuration.
+
+
+This is with the exception of Trollslayers and Ogres that may chose from a limited selection of equipment.
+
+
+The fighting style does not restrict Heroes from using items not on their list if they learn the appropriate skills.
+
+
+Pit Fighters may chose to change their fighting style at any stage by either swapping with another warrior in the warband or by simply buying a new style (or the separate components).
+
+
+Pit Fighter warbands also differ from other warbands in that a Henchman group may contain a mix of several different fighting styles and does not have to equip all of its warriors in the same manner.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="51e2-6ff7-f8ca-fc6b" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Stash" hidden="false" id="3bf7-c3d3-dcb6-7c9c" page="0" collective="false">
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="false" id="8cc5-92f8-91fe-12ac" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink name="Stash" hidden="false" id="9ce6-ec59-901e-e215" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Wyrdstone" hidden="false" id="1e1b-6b35-f153-77af" collective="false">
+          <costs>
+            <cost name="pts" typeId="points" value="0"/>
+            <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Trading Post" hidden="false" id="8667-da8d-37d5-6ce3" collective="false">
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="6166-7a33-3c00-7599" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5abb-da94-dcbb-bed2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <entryLinks>
+            <entryLink import="true" name="Equipment" hidden="false" id="ef84-e490-37d9-fe96" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
+          </costs>
+          <modifiers>
+            <modifier type="set" value="Equipment" field="name"/>
+          </modifiers>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="d5e3-4666-3713-0644" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0"/>
+        <cost name="Warband Rating" typeId="wb-rating" value="0"/>
+      </costs>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Possessed.cat
+++ b/Possessed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="39bde8be-ab13-2d3c-098b-1d52b4cbbf63" name="Cult of the Possessed (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="39bde8be-ab13-2d3c-098b-1d52b4cbbf63" name="Cult of the Possessed (1a)" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Beastmen" page="0" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -2631,6 +2631,18 @@ for details.</description>
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="1797-ccc9-5506-649f" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="7220-e563-9edb-b619" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="dcf4-463e-48eb-c34e-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="dcf4-463e-48eb-c34e-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="bd05-cf85-4e60-a865" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <infoLinks>

--- a/Reikland_Mercenaries.cat
+++ b/Reikland_Mercenaries.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ac1721e2-653d-e279-11e3-ca8ba77b0637" name="Reiklanders (1a)" revision="10" battleScribeVersion="2.03" authorUrl="https://github.com/BSData/mordheim/issues" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="ac1721e2-653d-e279-11e3-ca8ba77b0637" name="Reiklanders (1a)" revision="11" battleScribeVersion="2.03" authorUrl="https://github.com/BSData/mordheim/issues" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Champion" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -1672,6 +1672,27 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="2923-0319-d2e6-2a45" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="5917-5dc3-80af-523e" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="74c3-7294-01b1-3a0f-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="74c3-7294-01b1-3a0f-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Reikland Leadership" id="89a6-d116-725d-746a" hidden="false" page="0">
+          <description>Reikland Mercenaries are accustomed to the demands of military discipline and have a strongly developed loyalty between officers and men.
+To represent this, fighters may use their Captain’s Leadership if within 12&quot; rather than the usual 6&quot;.
+
+A strong tradition of martial training is also responsible for the high standards of archery amongst the people of Reikland.
+All Marksmen therefore add +1 to their Ballistic Skill, whether they are recruited when the warband is first formed or added later. (this is included in their profile)</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="16c1-4bbd-1be8-2188" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Remasens.cat
+++ b/Remasens.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ad3d-5780-c6dc-852" name="Remasens (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ad3d-5780-c6dc-852" name="Remasens (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="d0a6-e11-f742-4f0a" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -10,7 +10,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="bad6-67b1-79a4-d6c7" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="e1a7-e62e-8c3b-e162" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="63ba-142d-4629-1904" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="63ba-142d-4629-1904" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -36,7 +36,7 @@
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="f6af-4137-9d6a-7d72" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="9e77-2f3f-1364-1aa2" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="b263-a708-7fa5-447b" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="b263-a708-7fa5-447b" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
             <entryLink import="true" name="Longbow" hidden="false" id="5215-8173-69fe-99c3" type="selectionEntry" targetId="afa2-2d5c-54dd-d435"/>
             <entryLink import="true" name="Crossbow" hidden="false" id="e1b6-da99-df66-8868" type="selectionEntry" targetId="38cc-bc0b-7f19-8039"/>
             <entryLink import="true" name="Handgun" hidden="false" id="7b39-2f36-8cdf-7e0b" type="selectionEntry" targetId="7f5a-d04d-153d-d334"/>
@@ -48,7 +48,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="181d-2d32-34e9-63ee" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="ad10-c2be-4119-1fa9" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="ad10-c2be-4119-1fa9" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="ddbb-8e13-d0c5-35ca" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -60,7 +60,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="4a19-71f2-3a-91aa" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="5835-ef3-3572-2ad2" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="60d2-ec12-f291-9b" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="60d2-ec12-f291-9b" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -92,7 +92,7 @@
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="95e2-5b48-2526-8553" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="8ff7-7700-c789-c8d8" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="a83-7f82-407-2eb9" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="a83-7f82-407-2eb9" type="selectionEntry" targetId="da24-6a7f-725b-5bcb"/>
             <entryLink import="true" name="Bow" hidden="false" id="8b50-f882-c64d-7c1f" type="selectionEntry" targetId="311a-bf3f-67ff-46e7"/>
             <entryLink import="true" name="Crossbow" hidden="false" id="60a5-564-4fab-1703" type="selectionEntry" targetId="38cc-bc0b-7f19-8039"/>
           </entryLinks>
@@ -102,7 +102,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="bc76-dd4c-5744-a7ad" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="f8dc-a64-2c12-ded2" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="f8dc-a64-2c12-ded2" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="282f-7edd-df32-1c6b" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="112a-b639-5953-f823" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="f7e5-1454-92f-6868" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
@@ -306,7 +306,7 @@ This can bring the total leadership above the normal maximum for a regular human
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="3c8e-6d7-fd0f-3dd7" collective="false" targetId="70b2-3ff1-7190-c569" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="f4f7-e79f-6714-c2e8" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="176e-fd4f-219a-4f2a" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="3b93-9366-d51f-75f0" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="3b93-9366-d51f-75f0" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -603,7 +603,7 @@ This can bring the total leadership above the normal maximum for a regular human
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="be8c-1815-644b-5ef4" collective="false" targetId="70b2-3ff1-7190-c569" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="3554-c267-6165-e28" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="1087-4b2-cfb0-e667" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="1662-f0f2-5bfc-843" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="1662-f0f2-5bfc-843" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -936,7 +936,7 @@ This can bring the total leadership above the normal maximum for a regular human
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="f645-4627-aaf5-e173" collective="false" targetId="70b2-3ff1-7190-c569" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="3766-554f-605-ceb2" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="ee03-9ea4-f40d-1c0d" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="5ab7-9535-89e1-f598" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="5ab7-9535-89e1-f598" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1309,7 +1309,7 @@ This can bring the total leadership above the normal maximum for a regular human
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="8349-1cd4-5672-2c03" collective="false" targetId="70b2-3ff1-7190-c569" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="78ff-36cb-90b0-93e" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="78ff-36cb-90b0-93e" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1736,7 +1736,7 @@ This can bring the total leadership above the normal maximum for a regular human
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Tilean Equipment" hidden="false" id="835-7e1c-d019-bed5" collective="false" targetId="70b2-3ff1-7190-c569" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="fe6f-e1d6-d8e7-5b7d" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="fe6f-e1d6-d8e7-5b7d" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2174,7 +2174,7 @@ The Duellist counts as using a shield in close combat.</description>
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Marksman Equipment" hidden="false" id="ec03-2b94-1948-c9eb" collective="false" targetId="2a36-555a-c14a-4395" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="true" id="6a80-a640-673e-a03b" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="true" id="6a80-a640-673e-a03b" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -2461,7 +2461,11 @@ The Duellist counts as using a shield in close combat.</description>
         <categoryLink name="Stash" hidden="false" id="22ba-abf2-c4f6-45bd" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="3417-af68-96f1-6b79" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="3417-af68-96f1-6b79" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry" page="">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="837-68eb-e115-216e" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="99bc-136f-f31c-1cf3" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2469,6 +2473,52 @@ The Duellist counts as using a shield in close combat.</description>
         <cost name="pts" hidden="false" id="c94b-d1a8-5122-eb76" typeId="points" value="0"/>
         <cost name="Warband Rating" hidden="false" id="99ac-e506-6732-98f1" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="8474-bcab-2fcb-b201" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="2abf-af73-e681-0503" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="09a4-76e1-74be-404a-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="09a4-76e1-74be-404a-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hate Dark Elf" id="b289-eb8d-118e-c6b2" hidden="false">
+          <description>In 1487 a fleet of Dark EIf warships invaded the coastal city of Remas and ever since the people of that city have a deep dislike of the Druchii.
+
+
+A warband from Remas will fight to the death against any Dark EIf warband they encounter.
+
+
+To represent this, the Remasen player is allowed to re-roll any rout test one time and must abide by the second roll.
+
+
+This only applies when fighting Dark Elves.</description>
+        </rule>
+        <rule name="Hired Swords" id="3f39-8f92-079c-c00a" hidden="false">
+          <description>A Tilean warband can use any Hired Sword available to the Mercenary warbands including the following
+
+
+ - Shadow Warrior
+ - Big Game Hunter
+ - Expert Marksman
+
+
+Unless noted otherwise, Hired Swords cannot benefit from individual city-state rules given to each warband.</description>
+        </rule>
+        <rule name="Remasen Leadership" id="9c6a-0322-c9de-a9cb" hidden="false">
+          <description>Remasen officers are steadfast individuals whose years of training have afforded them excellent leadership.
+
+
+The leadership value of a Remasen captain, champion and young blood are always one point higher regardless of whom they are fighting.
+
+
+This can bring the total leadership above the normal maximum for a regular human.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="7c12-60cd-347c-515b" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
 </catalogue>

--- a/Sitsters_of_Sigmar.cat
+++ b/Sitsters_of_Sigmar.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c6b6bbc1-2d97-0206-16d1-5845aabffac4" name="Sisters of Sigmar (1a)" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="c6b6bbc1-2d97-0206-16d1-5845aabffac4" name="Sisters of Sigmar (1a)" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="83ab8692-01da-65c5-af52-a55d4800f012" name="Augur" page="0" hidden="false" collective="false" import="true" type="model">
       <constraints>
@@ -164,7 +164,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
                 <entryLink import="true" name="Flail" hidden="false" id="1fcd-6d17-493e-780a" collective="false" targetId="fea6-684b-02c4-6c62" type="selectionEntry" sortIndex="6"/>
                 <entryLink import="true" name="Hammer" hidden="false" id="a2c3-6d33-b991-2540" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="4"/>
                 <entryLink import="true" name="Double Handed Weapon" hidden="false" id="2e29-8e34-d916-d4a7" type="selectionEntry" targetId="a0a1-b311-e3aa-6c3b" sortIndex="8"/>
-                <entryLink import="true" name="Sigmarite Warhammer (Sisters only)" hidden="false" id="b65e-792a-39cf-615f" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
+                <entryLink import="true" name="Sigmarite Warhammer" hidden="false" id="b65e-792a-39cf-615f" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
                 <entryLink import="true" name="Steel Whip" hidden="false" id="8a43-93da-1a15-20d4" type="selectionEntry" sortIndex="7" targetId="1ce7-1431-21fc-6d18"/>
               </entryLinks>
               <constraints>
@@ -471,7 +471,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
                 <entryLink import="true" name="Flail" hidden="false" id="ad28-849d-3d89-5384" collective="false" targetId="fea6-684b-02c4-6c62" type="selectionEntry" sortIndex="6"/>
                 <entryLink import="true" name="Hammer" hidden="false" id="a791-1d43-1c0d-83e1" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="4"/>
                 <entryLink import="true" name="Double Handed Weapon" hidden="false" id="9b54-82fb-038f-6001" type="selectionEntry" targetId="a0a1-b311-e3aa-6c3b" sortIndex="8"/>
-                <entryLink import="true" name="Sigmarite Warhammer (Sisters only)" hidden="false" id="0053-de75-a4db-139b" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
+                <entryLink import="true" name="Sigmarite Warhammer" hidden="false" id="0053-de75-a4db-139b" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
                 <entryLink import="true" name="Steel Whip" hidden="false" id="f40b-cf20-8943-9b4d" type="selectionEntry" sortIndex="7" targetId="1ce7-1431-21fc-6d18"/>
               </entryLinks>
               <constraints>
@@ -731,7 +731,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
                 <entryLink import="true" name="Flail" hidden="false" id="1184-f08d-9bf7-f489" collective="false" targetId="fea6-684b-02c4-6c62" type="selectionEntry" sortIndex="6"/>
                 <entryLink import="true" name="Hammer" hidden="false" id="9288-c9bb-4626-0933" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="4"/>
                 <entryLink import="true" name="Double Handed Weapon" hidden="false" id="7cdf-e5d2-4a02-b1ad" type="selectionEntry" targetId="a0a1-b311-e3aa-6c3b" sortIndex="8"/>
-                <entryLink import="true" name="Sigmarite Warhammer (Sisters only)" hidden="false" id="b861-79d7-84d6-c12c" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
+                <entryLink import="true" name="Sigmarite Warhammer" hidden="false" id="b861-79d7-84d6-c12c" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
                 <entryLink import="true" name="Steel Whip" hidden="false" id="631d-a910-496c-9f95" type="selectionEntry" sortIndex="7" targetId="1ce7-1431-21fc-6d18"/>
               </entryLinks>
               <constraints>
@@ -1003,7 +1003,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
                 <entryLink import="true" name="Flail" hidden="false" id="28e1-8e1b-ce53-6d0b" collective="false" targetId="fea6-684b-02c4-6c62" type="selectionEntry" sortIndex="6"/>
                 <entryLink import="true" name="Hammer" hidden="false" id="4870-a4f1-2501-1944" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="4"/>
                 <entryLink import="true" name="Double Handed Weapon" hidden="false" id="27a4-56fc-63f9-7fc4" type="selectionEntry" targetId="a0a1-b311-e3aa-6c3b" sortIndex="8"/>
-                <entryLink import="true" name="Sigmarite Warhammer (Sisters only)" hidden="false" id="e99e-5b0b-e26e-e7e2" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
+                <entryLink import="true" name="Sigmarite Warhammer" hidden="false" id="e99e-5b0b-e26e-e7e2" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
                 <entryLink import="true" name="Steel Whip" hidden="false" id="7543-1332-b132-d2a8" type="selectionEntry" sortIndex="7" targetId="1ce7-1431-21fc-6d18"/>
               </entryLinks>
               <constraints>
@@ -1285,7 +1285,7 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
                 <entryLink import="true" name="Flail" hidden="false" id="bdab-cf02-0922-a15a" collective="false" targetId="fea6-684b-02c4-6c62" type="selectionEntry" sortIndex="6"/>
                 <entryLink import="true" name="Hammer" hidden="false" id="0a3c-1ae3-232e-83fe" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry" sortIndex="4"/>
                 <entryLink import="true" name="Double Handed Weapon" hidden="false" id="a4ec-fa51-a577-ea29" type="selectionEntry" targetId="a0a1-b311-e3aa-6c3b" sortIndex="8"/>
-                <entryLink import="true" name="Sigmarite Warhammer (Sisters only)" hidden="false" id="8894-24c5-f25c-ca78" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
+                <entryLink import="true" name="Sigmarite Warhammer" hidden="false" id="8894-24c5-f25c-ca78" type="selectionEntry" targetId="1478-15cf-1d4e-3e13" sortIndex="5"/>
                 <entryLink import="true" name="Steel Whip" hidden="false" id="5b5d-c4a8-d171-aac9" type="selectionEntry" sortIndex="7" targetId="1ce7-1431-21fc-6d18"/>
               </entryLinks>
               <constraints>
@@ -1440,6 +1440,18 @@ In addition, an Augur can use her Blessed Sight to help the Sisterhood when they
         <cost name="pts" typeId="points" value="0"/>
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="d6c8-4c8a-3b18-94f4" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="c783-3972-a093-a719" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="b2da-519c-8b41-a965-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="b2da-519c-8b41-a965-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="93f8-5736-60dd-df49" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <infoLinks>

--- a/Skaven of Clan Pestilens.cat
+++ b/Skaven of Clan Pestilens.cat
@@ -1,102 +1,102 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6518-bc7b-3999-c73f" name="Skaven of Clan Pestilens (1b)" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6518-bc7b-3999-c73f" name="Skaven of Clan Pestilens (1b)" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="f9b4-a273-8a78-ed19" name="Plague Priest" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eb0-f2ea-a7b-38a1" type="max"/>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcd6-85c1-aa7c-e8dd" type="min"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eb0-f2ea-a7b-38a1" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcd6-85c1-aa7c-e8dd" type="min"/>
       </constraints>
       <profiles>
         <profile id="cf2c-d5b0-90a9-a606" name="Plague Priest" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -123,21 +123,21 @@
       <selectionEntries>
         <selectionEntry id="a1bb-3454-a786-66f3" name="Trading Post" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd-b85e-d1bf-3092" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4824-98ed-6a19-c64c" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd-b85e-d1bf-3092" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4824-98ed-6a19-c64c" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="a03c-5bc5-104a-70d8" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4fb6-bb1c-cc32-3b2a" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3fd-204f-215c-429" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3fd-204f-215c-429" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="da6c-66d9-9df6-5c6" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
@@ -148,87 +148,87 @@
             <entryLink id="f084-b64d-bb90-a" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="1413-95d6-f0fb-fe45" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f609-e2eb-a273-779" type="min"/>
+            <constraint field="selections" scope="parent" value="20" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f609-e2eb-a273-779" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="bdf4-dae7-2dd-756b" name="Heroes Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
+        <entryLink id="bdf4-dae7-2dd-756b" name="Heroes Starting Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
         <entryLink id="4b-40a7-9eeb-8285" name="Characteristic Increases" hidden="false" collective="false" import="true" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink id="1ce8-fa85-d417-1f81" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
         <entryLink id="5da7-d763-4a48-6ee6" name="Advancement (Hero)" hidden="false" collective="false" import="true" targetId="c26e-414e-293-2621" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="23.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="27.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="31.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="45.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="23" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="56.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="62.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="68.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="75.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="27" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="82.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="31" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="89.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="35" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="40" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="45" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="50" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="56" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="62" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="68" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="75" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="82" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="89" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -239,8 +239,8 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8e3-3660-62ea-4311" type="atLeast"/>
-                    <condition field="selections" scope="f9b4-a273-8a78-ed19" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6b7-7177-f4b0-f407" type="atLeast"/>
+                    <condition field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8e3-3660-62ea-4311" type="atLeast"/>
+                    <condition field="selections" scope="f9b4-a273-8a78-ed19" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6b7-7177-f4b0-f407" type="atLeast"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -250,106 +250,106 @@
         <entryLink id="fb90-6c45-46fc-4a8e" name="Miscellaneous Equipment" hidden="false" collective="false" import="true" targetId="9cd4-fd73-6ae6-3e93" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" gc" typeId="points" value="85.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
+        <cost name=" gc" typeId="points" value="85"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8151-aaaf-1b26-7da8" name="Pestilens Sorcerer" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa89-b70b-eec4-91fc" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa89-b70b-eec4-91fc" type="max"/>
       </constraints>
       <profiles>
         <profile id="5f6a-6da5-58ed-ce42" name="Pestilens Sorcerer" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="8151-aaaf-1b26-7da8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -375,21 +375,21 @@
       <selectionEntries>
         <selectionEntry id="6051-3ee8-6f69-89a" name="Trading Post" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fd6-a08-ccbd-b1f2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9656-a8a5-89a0-8f5f" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fd6-a08-ccbd-b1f2" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9656-a8a5-89a0-8f5f" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="12fd-527d-cd28-5d56" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="708d-de5b-2090-3674" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a0-1242-45ac-3436" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a0-1242-45ac-3436" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b131-6bc5-3f35-4d73" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
@@ -397,107 +397,107 @@
             <entryLink id="6dd4-36a8-819a-bbbc" name="Special Skills (Skaven Pestilens)" hidden="false" collective="false" import="true" targetId="16e3-d71b-66e3-a530" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="5a64-7538-bda4-b8c8" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2bc-d6a4-41a7-a0c3" type="min"/>
+            <constraint field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2bc-d6a4-41a7-a0c3" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="6945-f816-7f8a-677e" name="Heroes Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
+        <entryLink id="6945-f816-7f8a-677e" name="Heroes Starting Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
         <entryLink id="5816-f3ad-d328-5d90" name="Characteristic Increases" hidden="false" collective="false" import="true" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink id="baea-b739-67a0-d07c" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
         <entryLink id="48f3-867b-b582-c8e7" name="Advancement (Hero)" hidden="false" collective="false" import="true" targetId="c26e-414e-293-2621" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="23.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="23" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="27.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="31.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="27" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="31" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="45.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="56.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="62.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="35" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="68.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="75.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="82.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="40" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="89.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="45" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="50" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="56" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="62" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="68" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="75" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="82" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="89" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="16" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -506,113 +506,113 @@
         <entryLink id="c1b0-5bd1-ed91-24e6" name="Miscellaneous Equipment" hidden="false" collective="false" import="true" targetId="9cd4-fd73-6ae6-3e93" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" gc" typeId="points" value="45.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
+        <cost name=" gc" typeId="points" value="45"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b330-8279-108d-9c4c" name="Plague Monks" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="decrement" field="rarity" value="1.0">
+        <modifier type="decrement" field="rarity" value="1">
           <repeats>
-            <repeat field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36c5-61d9-f515-c68e" repeats="9" roundUp="false"/>
+            <repeat field="selections" scope="self" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="36c5-61d9-f515-c68e" repeats="9" roundUp="false"/>
           </repeats>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e750-c3e8-f53c-ed4b" type="max"/>
+        <constraint field="selections" scope="roster" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e750-c3e8-f53c-ed4b" type="max"/>
       </constraints>
       <profiles>
         <profile id="90ff-f924-c372-910f" name="Plague Monks" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="b330-8279-108d-9c4c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -638,21 +638,21 @@
       <selectionEntries>
         <selectionEntry id="219-b6b2-c48c-48b1" name="Trading Post" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab5f-f9e9-1284-a49c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f51f-6e61-fae0-f3dc" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab5f-f9e9-1284-a49c" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f51f-6e61-fae0-f3dc" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="b702-11fe-71aa-238e" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="759-15fb-913d-9639" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd3-eed-ab3e-51aa" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd3-eed-ab3e-51aa" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="e566-363e-40f-3678" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
@@ -662,107 +662,107 @@
             <entryLink id="36bd-f357-9ef-658c" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="13fb-12cd-8ea5-147" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="336f-92a0-e82c-17ee" type="min"/>
+            <constraint field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="336f-92a0-e82c-17ee" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="5a5c-d784-76c9-d61b" name="Heroes Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
+        <entryLink id="5a5c-d784-76c9-d61b" name="Heroes Starting Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
         <entryLink id="b55e-8c0c-493c-f1ca" name="Characteristic Increases" hidden="false" collective="false" import="true" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink id="2f72-aa25-970b-dad6" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
         <entryLink id="5687-a3e4-2c1e-5215" name="Advancement (Hero)" hidden="false" collective="false" import="true" targetId="c26e-414e-293-2621" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="23.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="23" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="27.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="27" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="31.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="31" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="35" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="40" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="45.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="45" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="50" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="56.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="56" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="62.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="62" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="68.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="68" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="75.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="75" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="82.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="82" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="89.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="89" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="16" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -770,106 +770,106 @@
         <entryLink id="7103-93ee-27c6-139d" name="Miscellaneous Equipment" hidden="false" collective="false" import="true" targetId="9cd4-fd73-6ae6-3e93" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" gc" typeId="points" value="45.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
+        <cost name=" gc" typeId="points" value="45"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="818c-21b2-efca-98f0" name="Monk Initiates" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="949c-2da7-6ca0-18df" type="max"/>
+        <constraint field="selections" scope="roster" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="949c-2da7-6ca0-18df" type="max"/>
       </constraints>
       <profiles>
         <profile id="952d-1d64-efb1-61f2" name="Monk Initiates" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
           <modifiers>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="818c-21b2-efca-98f0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -895,21 +895,21 @@
       <selectionEntries>
         <selectionEntry id="8c9e-389f-5460-f38" name="Trading Post" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="937e-63cb-3d38-f85" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0dd-a871-3aea-f9d3" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="937e-63cb-3d38-f85" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0dd-a871-3aea-f9d3" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="65b9-a7eb-146e-ca6d" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7e18-6812-5499-c884" name="Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d0a-24b6-9c9b-178" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d0a-24b6-9c9b-178" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="6c3e-5660-538f-cea3" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
@@ -918,123 +918,123 @@
             <entryLink id="f467-906d-5058-51b7" name="Special Skills (Skaven Pestilens)" hidden="false" collective="false" import="true" targetId="16e3-d71b-66e3-a530" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="9b64-d42f-4b5b-6751" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry"/>
-        <entryLink id="ccb6-c79b-6012-9b33" name="Heroes Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
+        <entryLink id="ccb6-c79b-6012-9b33" name="Heroes Starting Equipment" hidden="false" collective="false" import="true" targetId="43a3-ee93-4d88-5310" type="selectionEntryGroup"/>
         <entryLink id="bdb5-1f30-6001-4fbf" name="Characteristic Increases" hidden="false" collective="false" import="true" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink id="3a12-7c9f-f204-54fc" name="Serious Injuries" hidden="false" collective="false" import="true" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
         <entryLink id="c2e3-42b8-ad95-207f" name="Advancement (Hero)" hidden="false" collective="false" import="true" targetId="c26e-414e-293-2621" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="23.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="27.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="31.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="23" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="45.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="27" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="56.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="62.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="68.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="75.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="82.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="89.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+                <condition field="selections" scope="parent" value="31" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="35" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="40" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="45" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="50" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="56" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="62" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="68" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="75" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="82" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="89" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="16" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="7" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1042,14 +1042,14 @@
         <entryLink id="852d-90c4-cc08-d619" name="Miscellaneous Equipment" hidden="false" collective="false" import="true" targetId="9cd4-fd73-6ae6-3e93" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name=" gc" typeId="points" value="20.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
+        <cost name=" gc" typeId="points" value="20"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c647-256-a3fa-2fb5" name="Rat Ogre" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80e1-e065-bf8a-acaf" type="max"/>
+        <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80e1-e065-bf8a-acaf" type="max"/>
       </constraints>
       <profiles>
         <profile id="4df6-a83-c994-2ce6" name="Rat Ogre" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
@@ -1081,10 +1081,22 @@
         <categoryLink id="4dfe-f7bb-2e79-86b1" name="Henchmen" hidden="false" targetId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" primary="true"/>
       </categoryLinks>
       <costs>
-        <cost name=" gc" typeId="points" value="210.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="20.0"/>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
+        <cost name=" gc" typeId="points" value="210"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="20"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="e26d-2c20-1dcc-ccd8" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="5593-2e3d-bd4a-ce62" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="f014-dbc3-aede-2eca-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="f014-dbc3-aede-2eca-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="a558-dc96-cf1d-d80d" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
@@ -1092,9 +1104,9 @@
     <entryLink id="a529-6290-611f-9440" name="Plague Novices" hidden="false" collective="false" import="true" targetId="6776-d653-eb5d-27bd" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="9600-a948-9b9c-df71" name="Disease Dagger" page="" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9600-a948-9b9c-df71" name="Disease Dagger" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="f418-3678-3d32-8b7a" name="Disease Dagger" page="" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
+        <profile id="f418-3678-3d32-8b7a" name="Disease Dagger" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
           <characteristics>
             <characteristic name="Str" typeId="f10cfcb7-b71e-4c27-9836-75d341e28f68">As user</characteristic>
             <characteristic name="Special" typeId="80dd3fd5-3811-af0b-e182-2ecbc7ad5d8e">+1 Armor Save, Infecting</characteristic>
@@ -1102,7 +1114,7 @@
         </profile>
       </profiles>
       <rules>
-        <rule id="e63a-1542-5be9-2ba4" name="Infecting" page="" hidden="false">
+        <rule id="e63a-1542-5be9-2ba4" name="Infecting" hidden="false">
           <description>A natural 6 on any to hit roll means that the model hit has been infected with the disease and that he must take a Toughness test.
 Roll a D6.
 
@@ -1112,8 +1124,8 @@ Models of undead and possessed are immune to this disease and do not take the te
 
 A model wielding two Disease Daggers gains a +1 Attack bonus for wielding two weapons and there is no further effect, except that the chances of rolling an infecting 6 on the hit rolls are higher.</description>
         </rule>
-        <rule id="2b58-6d33-9b25-4c5a" name="Rare" page="" hidden="false">
-          <description> 8</description>
+        <rule id="2b58-6d33-9b25-4c5a" name="Rare" hidden="false">
+          <description>8</description>
         </rule>
       </rules>
       <infoLinks>
@@ -1122,10 +1134,10 @@ A model wielding two Disease Daggers gains a +1 Attack bonus for wielding two we
       <selectionEntries>
         <selectionEntry id="691e-ece4-bf2c-0755" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="points" value="45.0"/>
+            <modifier type="set" field="points" value="45"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3765-8a10-ce6a-ec75" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3765-8a10-ce6a-ec75" type="max"/>
           </constraints>
           <rules>
             <rule id="04c6-3204-54b6-e88e" name="Rare" hidden="false">
@@ -1136,17 +1148,17 @@ A model wielding two Disease Daggers gains a +1 Attack bonus for wielding two we
             <infoLink id="9dfe-0081-10f4-ee4d" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="fe47-dc73-99a6-2fd0" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="points" value="60.0"/>
+            <modifier type="set" field="points" value="60"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8616-4a73-09bf-2024" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8616-4a73-09bf-2024" type="max"/>
           </constraints>
           <rules>
             <rule id="e042-98ec-ae92-b7c4" name="Rare" hidden="false">
@@ -1157,21 +1169,21 @@ A model wielding two Disease Daggers gains a +1 Attack bonus for wielding two we
             <infoLink id="8324-4703-269a-9bc8" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name=" gc" typeId="points" value="15.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-        <cost name=" Rarity" typeId="rarity" value="8.0"/>
+        <cost name=" gc" typeId="points" value="15"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+        <cost name=" Rarity" typeId="rarity" value="8"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="36c5-61d9-f515-c68e" name="Censer" page="" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="36c5-61d9-f515-c68e" name="Censer" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="677f-f532-8117-a777" name="Censer" page="" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
+        <profile id="677f-f532-8117-a777" name="Censer" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
           <characteristics>
             <characteristic name="Str" typeId="f10cfcb7-b71e-4c27-9836-75d341e28f68">As user +2</characteristic>
             <characteristic name="Special" typeId="80dd3fd5-3811-af0b-e182-2ecbc7ad5d8e">Fog of Death, Heavy, Two Handed</characteristic>
@@ -1191,7 +1203,7 @@ Models of undead and possessed are immune to the fog of death and do not take th
 If the model wielding the censer also has the fog-enhancing warpstone shards, he becomes a difficult target to shoot at, and models targeting him with missile weapons suffer a -1 penalty to hit.</description>
         </rule>
         <rule id="298f-be11-42ff-6303" name="Rare" hidden="false">
-          <description> 9</description>
+          <description>9</description>
         </rule>
       </rules>
       <infoLinks>
@@ -1201,10 +1213,10 @@ If the model wielding the censer also has the fog-enhancing warpstone shards, he
       <selectionEntries>
         <selectionEntry id="d970-d8be-f701-b7c5" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="points" value="120.0"/>
+            <modifier type="set" field="points" value="120"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c63d-ba09-66e1-5ffa" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c63d-ba09-66e1-5ffa" type="max"/>
           </constraints>
           <rules>
             <rule id="50bf-4936-c354-f6b0" name="Rare" hidden="false">
@@ -1215,17 +1227,17 @@ If the model wielding the censer also has the fog-enhancing warpstone shards, he
             <infoLink id="6d86-95d6-4049-2a1d" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a687-2f76-b75c-bb89" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="points" value="80.0"/>
+            <modifier type="set" field="points" value="80"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="306d-7387-95b5-f509" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="306d-7387-95b5-f509" type="max"/>
           </constraints>
           <rules>
             <rule id="982c-7478-dff0-eaec" name="Rare" hidden="false">
@@ -1236,16 +1248,16 @@ If the model wielding the censer also has the fog-enhancing warpstone shards, he
             <infoLink id="c3b9-a98f-30fc-764a" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name=" gc" typeId="points" value="40.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-        <cost name=" Rarity" typeId="rarity" value="9.0"/>
+        <cost name=" gc" typeId="points" value="40"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+        <cost name=" Rarity" typeId="rarity" value="9"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="78b0-e3dc-3c14-5611" name="Giant Rats" hidden="false" collective="true" import="true" type="upgrade">
@@ -1254,87 +1266,87 @@ If the model wielding the censer also has the fog-enhancing warpstone shards, he
           <modifiers>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -1373,8 +1385,8 @@ If the model wielding the censer also has the fog-enhancing warpstone shards, he
       <selectionEntries>
         <selectionEntry id="db4d-81bf-57c4-c7a9" name="Rat Familiar" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="780a-6148-f5ec-290c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4009-ee74-bc2b-cb8b" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="780a-6148-f5ec-290c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4009-ee74-bc2b-cb8b" type="max"/>
           </constraints>
           <rules>
             <rule id="f0d8-3c76-1456-b1cd" name="Enchanted Animal" hidden="false">
@@ -1388,26 +1400,26 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
             </rule>
           </rules>
           <costs>
-            <cost name=" gc" typeId="points" value="15.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="15"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9f48-4565-cd10-ec2e" name="Giant Rat" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
+                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a39-7a97-30f8-b9dc" type="max"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a39-7a97-30f8-b9dc" type="max"/>
           </constraints>
           <costs>
-            <cost name=" gc" typeId="points" value="15.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="15"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1416,7 +1428,7 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
+                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1425,7 +1437,7 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
+                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1434,52 +1446,52 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
+                    <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <costs>
-                <cost name=" gc" typeId="points" value="0.0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-                <cost name=" Rarity" typeId="rarity" value="0.0"/>
+                <cost name=" gc" typeId="points" value="0"/>
+                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+                <cost name=" Rarity" typeId="rarity" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </entryLink>
         <entryLink id="fc6e-bfd8-7616-71b6" name="Advancement (Henchmen)" hidden="true" collective="false" import="true" targetId="583e-a0c5-873-acdc" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
+                <condition field="selections" scope="78b0-e3dc-3c14-5611" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db4d-81bf-57c4-c7a9" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
-        <cost name=" gc" typeId="points" value="0.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
+        <cost name=" gc" typeId="points" value="0"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6776-d653-eb5d-27bd" name="Plague Novices" hidden="false" collective="true" import="true" type="unit">
@@ -1488,92 +1500,92 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="increment" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7418-394e-fe13-2a96" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7918-b440-5d63-bd5e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37c4-dcb1-8949-d4eb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-7b50-a4f9-cd5f" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a83-274a-bba8-f498" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da26-8381-781a-6149" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27d8-c790-a4c1-b9cc" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe1-7bba-3ca0-06b7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="increment" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9368-3616-516f-5178" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="bf393c37-9d10-fc85-c147-62b1c01a89fe" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9faf-d3bf-a2ba-411e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7f1f0a4d-68dc-b0df-5703-c4d0d91a93b9" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e57-5d0b-5279-b4ab" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5b4d181b-23ae-5ed7-9262-c1d2f79246a8" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e79-80b9-77e3-fcc9" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3172c8dc-ebe4-0c40-72ab-8fd0076b9442" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9209-0067-18d2-b78c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="e234eaea-a02a-2fb7-3e1f-605392aabb89" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a519-13dc-1b04-e39e" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="2a0bcc4c-8266-418f-13d6-a6b44def5e92" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dee-74f8-7707-ce64" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="54f4796b-dedb-c296-8b1a-ff7f8043293a" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca62-64c2-488a-f17c" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="a6fd52b0-be0a-655e-6314-87b392c9c90e" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7531-eebe-fabf-7cf5" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d5aca8ba-0204-b324-b976-c2b536e09924" value="1">
               <repeats>
-                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="6776-d653-eb5d-27bd" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae44-58f4-4440-5777" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -1601,32 +1613,32 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fc4-213a-edea-f246" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea1f-c4e0-1a21-bd8c" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fc4-213a-edea-f246" type="min"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea1f-c4e0-1a21-bd8c" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="f990-1f1a-339a-169c" name="Equipment" hidden="false" collective="false" import="true" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4b8f-85d5-0fe9-1603" name="Plague Novice" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10da-c6b2-54f8-1c9c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60a-2d15-1f6a-936a" type="min"/>
+            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10da-c6b2-54f8-1c9c" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60a-2d15-1f6a-936a" type="min"/>
           </constraints>
           <costs>
-            <cost name=" gc" typeId="points" value="20.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="5.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="20"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1635,118 +1647,118 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <selectionEntryGroups>
             <selectionEntryGroup id="1120-624f-b80a-9f7f" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
               <modifiers>
-                <modifier type="set" field="a9aa-3ded-04c3-e5b5" value="3.0">
+                <modifier type="set" field="a9aa-3ded-04c3-e5b5" value="3">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d0b-ed37-d8b0-4cbf" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d0b-ed37-d8b0-4cbf" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9aa-3ded-04c3-e5b5" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9aa-3ded-04c3-e5b5" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="229c-00dd-76ab-5354" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="2.0">
+                    <modifier type="increment" field="points" value="2">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="2.0"/>
+                    <modifier type="decrement" field="points" value="2"/>
                   </modifiers>
                 </entryLink>
                 <entryLink id="cae2-7a61-dcc8-a4b7" name="Free Dagger" hidden="false" collective="false" import="true" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
                 <entryLink id="5d92-9a2d-6979-6baf" name="Club" hidden="false" collective="false" import="true" targetId="b43f-0d15-1f20-7fda" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
+                    <modifier type="increment" field="points" value="3">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="3.0"/>
+                    <modifier type="decrement" field="points" value="3"/>
                   </modifiers>
                 </entryLink>
                 <entryLink id="3b67-9f47-b32a-b89c" name="Sword" hidden="false" collective="false" import="true" targetId="34fd-d6a3-50ee-ee06" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="10.0">
+                    <modifier type="increment" field="points" value="10">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="10.0"/>
+                    <modifier type="decrement" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
                 <entryLink id="9292-74e0-3ab6-ea3d" name="Spear" hidden="false" collective="false" import="true" targetId="005e-e397-8108-f198" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="10.0">
+                    <modifier type="increment" field="points" value="10">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="10.0"/>
+                    <modifier type="decrement" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="2e3c-83da-f5e9-9108" name="Missile Weapons" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3788-016c-145f-4907" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3788-016c-145f-4907" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="aa5f-b01a-09c1-2385" name="Sling" hidden="false" collective="false" import="true" targetId="87c7-49b5-f1e7-6662" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="2.0">
+                    <modifier type="increment" field="points" value="2">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="2.0"/>
+                    <modifier type="decrement" field="points" value="2"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8e0-16a6-903b-fe53" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8e0-16a6-903b-fe53" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="1425-1f98-08bd-e1fa" name="Armour" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="daa9-6d24-57d3-e266" name="Light Armor" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry">
+                <entryLink id="daa9-6d24-57d3-e266" name="Light Armour" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="20.0">
+                    <modifier type="increment" field="points" value="20">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="20.0"/>
+                    <modifier type="decrement" field="points" value="20"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81c4-ffe5-fb0a-4c30" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81c4-ffe5-fb0a-4c30" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="6f18-9707-ed46-38e9" name="Shield" hidden="false" collective="false" import="true" targetId="74fb-cc90-1361-df26" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="5.0">
+                    <modifier type="increment" field="points" value="5">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="5.0"/>
+                    <modifier type="decrement" field="points" value="5"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88c3-88e1-d08e-3f28" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88c3-88e1-d08e-3f28" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="c6a4-4ed0-774f-c438" name="Helmet" hidden="false" collective="false" import="true" targetId="d0e5-ca89-5f0d-f5d2" type="selectionEntry">
                   <modifiers>
-                    <modifier type="increment" field="points" value="10.0">
+                    <modifier type="increment" field="points" value="10">
                       <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                        <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="decrement" field="points" value="10.0"/>
+                    <modifier type="decrement" field="points" value="10"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b181-5fbd-b897-b53c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b181-5fbd-b897-b53c" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -1757,12 +1769,12 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
       <entryLinks>
         <entryLink id="af80-f244-8d21-bc71" name="Experience" hidden="false" collective="false" import="true" targetId="d769-0d85-e810-df60" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="wb-rating" value="1.0">
+            <modifier type="increment" field="wb-rating" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8f-85d5-0fe9-1603" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="decrement" field="wb-rating" value="1.0"/>
+            <modifier type="decrement" field="wb-rating" value="1"/>
           </modifiers>
         </entryLink>
         <entryLink id="1067-9982-f453-5204" name="Promoted" hidden="false" collective="false" import="true" targetId="534a-6ec6-5d82-da7f" type="selectionEntry"/>
@@ -1771,160 +1783,160 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="4f82-2d0f-b21b-6072" name="Skills" hidden="true" collective="false" import="true" targetId="e8cb-e24-349-a81c" type="selectionEntryGroup">
+        <entryLink id="4f82-2d0f-b21b-6072" name="Skill Lists" hidden="true" collective="false" import="true" targetId="e8cb-e24-349-a81c" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
         <entryLink id="3805-41e2-5ac5-4038" name="Advancement (Hero)" hidden="true" collective="false" import="true" targetId="c26e-414e-293-2621" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="23.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="27.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="31.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="45.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="56.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="62.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="68.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="75.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="82.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="89.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="23" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="16.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
-              <conditions>
-                <condition field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="27" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="31" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="35" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="40" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="45" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1.0">
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="50" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="56" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="62" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="68" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="75" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="82" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="89" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="ancestor" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="instanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="19" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="16" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="7" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a79c-4fb2-4100-9f13" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
         <entryLink id="f593-84f5-6ea6-c61b" name="Advancement (Henchmen)" hidden="false" collective="false" import="true" targetId="583e-a0c5-873-acdc" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="8" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1.0">
+            <modifier type="increment" field="c8c2-da7f-edc5-5630" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="13" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d769-0d85-e810-df60" type="greaterThan"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1933,16 +1945,16 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="534a-6ec6-5d82-da7f" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name=" Rarity" typeId="rarity" value="0.0"/>
-        <cost name=" gc" typeId="points" value="0.0"/>
-        <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
+        <cost name=" Rarity" typeId="rarity" value="0"/>
+        <cost name=" gc" typeId="points" value="0"/>
+        <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1951,14 +1963,14 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
       <selectionEntryGroups>
         <selectionEntryGroup id="446c-7464-ec4-1566" name="Hand to Hand Weapons" hidden="false" collective="false" import="true">
           <modifiers>
-            <modifier type="set" field="de2d-eec2-60f3-aef4" value="3.0">
+            <modifier type="set" field="de2d-eec2-60f3-aef4" value="3">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d0b-ed37-d8b0-4cbf" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d0b-ed37-d8b0-4cbf" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2d-eec2-60f3-aef4" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2d-eec2-60f3-aef4" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="f57e-8b7-5295-ccbf" name="Dagger" hidden="false" collective="false" import="true" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
@@ -1974,12 +1986,12 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
         </selectionEntryGroup>
         <selectionEntryGroup id="111f-1692-7570-dc36" name="Missile Weapons" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8411-6664-b4d-ff1e" type="max"/>
+            <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8411-6664-b4d-ff1e" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="67a3-7a9e-b830-4fb0" name="Sling" hidden="false" collective="false" import="true" targetId="87c7-49b5-f1e7-6662" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5f3-f17a-7bcf-6591" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5f3-f17a-7bcf-6591" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -1988,17 +2000,17 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <entryLinks>
             <entryLink id="9062-7617-71ad-d5c" name="Light Armour" hidden="false" collective="false" import="true" targetId="3d2a-426a-c350-2a03" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b101-7a7e-f7f5-1ec2" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b101-7a7e-f7f5-1ec2" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="4e0b-5d87-74f3-cdb9" name="Shield" hidden="false" collective="false" import="true" targetId="74fb-cc90-1361-df26" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90b2-6535-dbee-75ea" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90b2-6535-dbee-75ea" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="50b1-5cd8-ea6d-c33c" name="Helmet" hidden="false" collective="false" import="true" targetId="d0e5-ca89-5f0d-f5d2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd00-e961-2f21-b058" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd00-e961-2f21-b058" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -2011,12 +2023,12 @@ A result of 10 - 12 on the henchmen advancement table, instead of the promotio
           <modifiers>
             <modifier type="set" field="bad3-63eb-7c90-390e" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c1f-68d4-e6e7-cc02" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c1f-68d4-e6e7-cc02" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bad3-63eb-7c90-390e" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bad3-63eb-7c90-390e" type="max"/>
           </constraints>
           <rules>
             <rule id="fa32-1b08-7184-5eda" name="Contagious" page="0" hidden="false">
@@ -2031,21 +2043,21 @@ Models of undead and possessed never take this test.</description>
             </rule>
           </rules>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d3d9-599a-a82f-d6a4" name="Censer Bearer" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="e43-27b7-83b-d962" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b91-4934-7397-fd3e" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b91-4934-7397-fd3e" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e43-27b7-83b-d962" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e43-27b7-83b-d962" type="max"/>
           </constraints>
           <rules>
             <rule id="fc9d-2258-6c85-2230" name="Censer Bearer" page="0" hidden="false">
@@ -2060,14 +2072,14 @@ He gains the special rule frenzy and the only weapon he may use in close combat 
             <infoLink id="e99d-4981-1302-63d0" name="Frenzy" hidden="false" targetId="ce28-23a1-7b2a-7e6c" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6c1f-68d4-e6e7-cc02" name="Rotten Body" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f776-a6e8-dd0d-a846" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f776-a6e8-dd0d-a846" type="max"/>
           </constraints>
           <rules>
             <rule id="e58b-306f-e980-433a" name="Rotten Body" page="0" hidden="false">
@@ -2076,21 +2088,21 @@ He is now immune to poison and diseases and, if take out of combat because of a 
             </rule>
           </rules>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="83c0-fd7c-4cdf-5d6b" name="Ignore Pain" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="5b4-aca8-50c4-3c42" value="1">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0239-b9df-15c7-b504" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0239-b9df-15c7-b504" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5b4-aca8-50c4-3c42" type="max"/>
+            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5b4-aca8-50c4-3c42" type="max"/>
           </constraints>
           <rules>
             <rule id="e7ce-e67b-3a99-eeb" name="Ignore Pain" page="0" hidden="false">
@@ -2101,14 +2113,14 @@ A Clan Pestilens member with this skill treats &quot;Stunned&quot; injuries as &
             </rule>
           </rules>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9b91-4934-7397-fd3e" name="Black Hunger" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f9b4-e3-a178-34b9" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f9b4-e3-a178-34b9" type="max"/>
           </constraints>
           <rules>
             <rule id="433c-7a1d-e887-b4d0" name="Black Hunger" page="0" hidden="false">
@@ -2117,95 +2129,95 @@ The Hero may add +1 attack and +D3&quot; to the total move to his profile for th
             </rule>
           </rules>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="e8cb-e24-349-a81c" name="Skill Lists" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f17-8b5b-90a8-f67f" type="max"/>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2aec-45e8-7fe5-a2d3" type="min"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f17-8b5b-90a8-f67f" type="max"/>
+        <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2aec-45e8-7fe5-a2d3" type="min"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="8e93-f264-b7c6-f91f" name="Academic Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df03-a06-9686-ab1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df03-a06-9686-ab1" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="e769-4300-eb5b-805a" name="Academic Skills" hidden="false" collective="false" import="true" targetId="df9d-8724-d362-9d7c" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4846-78dd-c9b7-fb60" name="Combat Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe80-b372-9a6c-b0e1" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe80-b372-9a6c-b0e1" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="bab0-eb47-10-1dab" name="Combat Skills" hidden="false" collective="false" import="true" targetId="ee2c-89e3-489b-d0cb" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="84f1-2b3-65ad-3777" name="Shooting Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d053-cea0-ab7a-564a" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d053-cea0-ab7a-564a" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="5144-703c-8759-3bc9" name="Shooting Skills" hidden="false" collective="false" import="true" targetId="0073-d2d6-15c0-45b1" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3fac-48b1-8178-9d5f" name="Speed Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1896-9df8-e1d0-7179" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1896-9df8-e1d0-7179" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="7453-a53d-7e0-7197" name="Speed Skills" hidden="false" collective="false" import="true" targetId="e134-0fdf-67a2-4684" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="3bfd-18fa-8237-18b" name="Strength Skills" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d7d-3029-d9e8-1f12" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d7d-3029-d9e8-1f12" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="32d2-e8c2-62d4-6361" name="Strength Skills" hidden="false" collective="false" import="true" targetId="e5ac-cd5b-9057-e096" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="97dd-ce6-f2e2-dbf5" name="Special Skills (Skaven Pestilens)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd3-4bdb-7fbb-fae5" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbd3-4bdb-7fbb-fae5" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="fc08-761e-76a-8e48" name="Special Skills (Skaven Pestilens)" hidden="false" collective="false" import="true" targetId="16e3-d71b-66e3-a530" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2214,7 +2226,7 @@ The Hero may add +1 attack and +D3&quot; to the total move to his profile for th
       <selectionEntries>
         <selectionEntry id="f2a-7721-5748-90a3" name="2 - Children of the Horned Rat" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa48-856e-30b7-2d0d" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa48-856e-30b7-2d0d" type="max"/>
           </constraints>
           <profiles>
             <profile id="b427-a34f-e337-4882" name="Children of the Horned Rat" hidden="false" typeId="d891-ee2b-b7dc-f545" typeName="Magic">
@@ -2230,14 +2242,14 @@ They do not count towards the maximum size of the Skaven warband.</characteristi
             </profile>
           </profiles>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e18-19f2-b4be-6feb" name="1 - Warpfire" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c963-651b-52ae-d9cc" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c963-651b-52ae-d9cc" type="max"/>
           </constraints>
           <profiles>
             <profile id="82df-7f6-eca9-6bee" name="Warpfire" hidden="false" typeId="d891-ee2b-b7dc-f545" typeName="Magic">
@@ -2249,14 +2261,14 @@ The spell causes D3 Strength 4 hits on its target, and one Strength 3 hit on eac
             </profile>
           </profiles>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aac3-e922-141-656f" name="3 - Gnawdoom" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e08c-8bfb-754b-a8ba" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e08c-8bfb-754b-a8ba" type="max"/>
           </constraints>
           <profiles>
             <profile id="a3ba-fc5f-92b3-352a" name="Gnawdoom" hidden="false" typeId="d891-ee2b-b7dc-f545" typeName="Magic">
@@ -2267,14 +2279,14 @@ The spell causes D3 Strength 4 hits on its target, and one Strength 3 hit on eac
             </profile>
           </profiles>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c852-e6f0-e91f-b37d" name="5 - Eye of the Warp" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ec1-8296-e9ea-41b0" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ec1-8296-e9ea-41b0" type="max"/>
           </constraints>
           <profiles>
             <profile id="56cc-2adf-d446-5a5f" name="Eye of the Warp" hidden="false" typeId="d891-ee2b-b7dc-f545" typeName="Magic">
@@ -2288,14 +2300,14 @@ If they fail, they each suffer a Strength 3 hit and must run 2D6 directly away f
             </profile>
           </profiles>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9446-d9ae-cba8-a9e8" name="6 - Sorcerer&apos;s Curse" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2c4-7474-ccd3-a229" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2c4-7474-ccd3-a229" type="max"/>
           </constraints>
           <profiles>
             <profile id="5b2a-84af-8283-53a2" name="Sorcerer&apos;s Curse" hidden="false" typeId="d891-ee2b-b7dc-f545" typeName="Magic">
@@ -2309,14 +2321,14 @@ The target must re-roll any successful armor saves and to hit rolls during the S
             </profile>
           </profiles>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f906-46c4-68ba-73e3" name="4 - Black Fury" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4101-24ec-e75e-3ca3" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4101-24ec-e75e-3ca3" type="max"/>
           </constraints>
           <profiles>
             <profile id="c438-6e3a-8b3-a9f3" name="Black Fury" hidden="false" typeId="d891-ee2b-b7dc-f545" typeName="Magic">
@@ -2327,9 +2339,9 @@ The target must re-roll any successful armor saves and to hit rolls during the S
             </profile>
           </profiles>
           <costs>
-            <cost name=" gc" typeId="points" value="0.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="0.0"/>
+            <cost name=" gc" typeId="points" value="0"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2342,22 +2354,22 @@ The target must re-roll any successful armor saves and to hit rolls during the S
               <description>The owner of a warpstone amulet may reroll a single die during the battle or, if not out of combat at the end of the game, a single die when looking for wyrdstone shards (Clan Pestilens members use this item instead of the Rabbit&apos;s Foot).</description>
             </rule>
             <rule id="db03-f3d3-3a69-73ed" name="Rare" hidden="false">
-              <description> 5</description>
+              <description>5</description>
             </rule>
           </rules>
           <selectionEntries>
             <selectionEntry id="c245-8959-29e8-53c3" name="Dummy" hidden="true" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name=" gc" typeId="points" value="0.0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-                <cost name=" Rarity" typeId="rarity" value="0.0"/>
+                <cost name=" gc" typeId="points" value="0"/>
+                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+                <cost name=" Rarity" typeId="rarity" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name=" gc" typeId="points" value="10.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="5.0"/>
+            <cost name=" gc" typeId="points" value="10"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="5"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b8e3-3660-62ea-4311" name="Liber Bubonicus" hidden="false" collective="false" import="true" type="upgrade">
@@ -2372,7 +2384,7 @@ A Plague Priest may use the Liber Bubonicus to learn the Horned Rat magic if he
 The Liber Bubonicus may be used a single time, and a warband cannot have and use more than one Liber Bubonicus in a given campaign (Clan Pestilens members use this item instead of the Tome of Magic).</description>
             </rule>
             <rule id="08c8-f867-09e2-51e9" name="Rare" hidden="false">
-              <description> 12</description>
+              <description>12</description>
             </rule>
           </rules>
           <entryLinks>
@@ -2381,27 +2393,27 @@ The Liber Bubonicus may be used a single time, and a warband cannot have and u
                 <modifier type="set" field="name" value="Variable Gold Cost, D6 x 25:"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb2-7390-9469-c4c5" type="min"/>
-                <constraint field="selections" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e011-a583-1472-48a2" type="max"/>
+                <constraint field="selections" scope="parent" value="25" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcb2-7390-9469-c4c5" type="min"/>
+                <constraint field="selections" scope="parent" value="150" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e011-a583-1472-48a2" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="200.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="12.0"/>
+            <cost name=" gc" typeId="points" value="200"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="12"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7581-cb1a-2c78-9ed4" name="Fog-enhancing warpstone shards" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="b8e8-f1fd-66bc-805" name="Fog-enhancing warpstone shards" page="" hidden="false">
+            <rule id="b8e8-f1fd-66bc-805" name="Fog-enhancing warpstone shards" hidden="false">
               <description>When put inside a censer these warpstone shards have the peculiar characteristic of making the resulting clouds of pestilential fumes thickier than usual.
 
 
 The wielder of a censer who also have some fog-enhancing warpstone shards is a difficult target to shoot at, and other models suffer a -1 penalty to hit when targetting him with missile weapons (Clan Pestilens members use this item instead of the Elven Cloak).</description>
             </rule>
             <rule id="6e01-793d-888c-2f12" name="Rare" hidden="false">
-              <description>  9</description>
+              <description>9</description>
             </rule>
           </rules>
           <entryLinks>
@@ -2410,15 +2422,15 @@ The wielder of a censer who also have some fog-enhancing warpstone shards is a
                 <modifier type="set" field="name" value="Variable Gold Cost, D6 x 10:"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6f7-d7fd-79fe-cdb5" type="min"/>
-                <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42a4-9047-b548-e305" type="max"/>
+                <constraint field="selections" scope="parent" value="10" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6f7-d7fd-79fe-cdb5" type="min"/>
+                <constraint field="selections" scope="parent" value="60" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42a4-9047-b548-e305" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="100.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="9.0"/>
+            <cost name=" gc" typeId="points" value="100"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="9"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="cdd9-604e-5001-28cf" name="Liturgicus Infecticus" hidden="false" collective="false" import="true" type="upgrade">
@@ -2433,7 +2445,7 @@ This is the Clan Pestilens chant in favour of diseases and contagion.
 At the beginning of a turn, or just before taking a Route Test, the warband may chant the Liturgicus lnfecticus, and benefit of a +1 Leadership bonus until the end of the turn. (Clan Pestilens members use this item instead of the Warhorn).</description>
             </rule>
             <rule id="aa16-56a0-f4a7-74f8" name="Rare" hidden="false">
-              <description> 8</description>
+              <description>8</description>
             </rule>
           </rules>
           <entryLinks>
@@ -2442,15 +2454,15 @@ At the beginning of a turn, or just before taking a Route Test, the warband 
                 <modifier type="set" field="name" value="Variable Gold Cost, 2D6:"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="973e-63c1-3a32-6ab6" type="min"/>
-                <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d2-5098-e3c-20cb" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="973e-63c1-3a32-6ab6" type="min"/>
+                <constraint field="selections" scope="parent" value="12" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d2-5098-e3c-20cb" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="30.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="8.0"/>
+            <cost name=" gc" typeId="points" value="30"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="8"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="456f-4c93-bf78-3670" name="Scroll of the Rat Familiar" hidden="false" collective="false" import="true" type="upgrade">
@@ -2465,7 +2477,7 @@ A sorcerer may only have one Rat Familiar at any one time, it is an henchman 
 If the sorcerer dies, his Rat Familiar turns back to Giant Rat form. (Clan Pestilens members use this item instead of the normal Familiar).</description>
             </rule>
             <rule id="d45c-ad08-172d-26ed" name="Rare" hidden="false">
-              <description> 8</description>
+              <description>8</description>
             </rule>
           </rules>
           <entryLinks>
@@ -2474,20 +2486,20 @@ If the sorcerer dies, his Rat Familiar turns back to Giant Rat form. (Clan Pe
                 <modifier type="set" field="name" value="Variable Gold Cost, D6:"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cec0-9d66-5101-8d02" type="min"/>
-                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76b-32a8-b994-7917" type="max"/>
+                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cec0-9d66-5101-8d02" type="min"/>
+                <constraint field="selections" scope="parent" value="6" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76b-32a8-b994-7917" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name=" gc" typeId="points" value="25.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="8.0"/>
+            <cost name=" gc" typeId="points" value="25"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="8"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="38d5-f23e-65ec-94d4" name="Clan Pestilens Banner" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59ba-e697-5790-356e" type="max"/>
+            <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59ba-e697-5790-356e" type="max"/>
           </constraints>
           <rules>
             <rule id="1737-ca9c-4f24-8f81" name="Clan Pestilens Banner" hidden="false">
@@ -2501,22 +2513,22 @@ A warband may have a single Clan Pestilens banner at any one time.
 (Clan Pestilens members use this item instead of the normal Banner).</description>
             </rule>
             <rule id="8d1f-83d7-45c6-20ae" name="Rare" hidden="false">
-              <description> 5</description>
+              <description>5</description>
             </rule>
           </rules>
           <selectionEntries>
             <selectionEntry id="a607-930f-9acb-1b9d" name="Dummy" hidden="true" collective="false" import="true" type="upgrade">
               <costs>
-                <cost name=" gc" typeId="points" value="0.0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-                <cost name=" Rarity" typeId="rarity" value="0.0"/>
+                <cost name=" gc" typeId="points" value="0"/>
+                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+                <cost name=" Rarity" typeId="rarity" value="0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
-            <cost name=" gc" typeId="points" value="10.0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0.0"/>
-            <cost name=" Rarity" typeId="rarity" value="5.0"/>
+            <cost name=" gc" typeId="points" value="10"/>
+            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
+            <cost name=" Rarity" typeId="rarity" value="5"/>
           </costs>
         </selectionEntry>
       </selectionEntries>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="facb1142-7463-7676-00c0-d78150e13a50" name="Skaven (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="facb1142-7463-7676-00c0-d78150e13a50" name="Skaven (1a)" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="facb1142--pubN71023" name="Mordheim Official"/>
   </publications>
@@ -1532,6 +1532,18 @@
           </conditions>
         </modifier>
       </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="f088-8223-112a-853d" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="da0d-45d5-eb4b-c121" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="1fe4-b03d-8b96-0b2f-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="1fe4-b03d-8b96-0b2f-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="77d0-40f6-ab16-8980" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <infoLinks>

--- a/Sons of Hashut.cat
+++ b/Sons of Hashut.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="cd0a-cc34-9315-94b7" name="Sons of Hashut" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="cd0a-cc34-9315-94b7" name="Sons of Hashut" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <rules>
     <rule name="Hard Head" id="99c6-f9b5-ef8e-6c4a" hidden="false">
       <description>Chaos Dwarfs ignore the special rules for maces, clubs, etc. They are not easy to knock out!</description>
@@ -53,7 +53,7 @@ They may never hire Elves of any sort!</description>
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="349-c02d-c6df-e7c1" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="9029-a15f-d2a6-d66b" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="4384-728-3c61-9111" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="4384-728-3c61-9111" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Mace, Hammer" field="name"/>
               </modifiers>
@@ -79,9 +79,9 @@ They may never hire Elves of any sort!</description>
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="bbcb-d564-98ad-275a" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="9340-9298-1d98-6048" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="9340-9298-1d98-6048" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="d012-6a1d-5454-c311" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="3"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="2f9f-3bfd-3e5d-21ea" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="2f9f-3bfd-3e5d-21ea" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="ee33-b000-31b-815a" type="selectionEntry" targetId="0871-44c2-f0f0-c27a" sortIndex="4"/>
             <entryLink import="true" name="Helmet" hidden="false" id="cdb-ae88-168f-d574" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2" sortIndex="5"/>
           </entryLinks>
@@ -101,4 +101,64 @@ They may never hire Elves of any sort!</description>
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="3cc3-e013-737f-b04f" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="cfdc-314e-80db-8df1" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="d447-ee56-7e35-c4ad" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="7aa4-8499-140b-c83a-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="7aa4-8499-140b-c83a-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Armour" id="03cf-435e-98a5-4ecd" hidden="false">
+          <description>Chaos Dwarfs and Centaurs never suffer movement penalties for wearing armour.</description>
+        </rule>
+        <rule name="Hard Head" id="6f8a-180e-c943-ffb3" hidden="false">
+          <description>Chaos Dwarfs ignore the special rules for maces, clubs, etc. They are not easy to knock out!</description>
+        </rule>
+        <rule name="Hard to Kill" id="c4b4-1ddd-310d-c746" hidden="false">
+          <description>Chaos Dwarfs and Centaurs are tough, resilient individuals who can only be taken out of action on a roll of 6 instead of 5-6 when rolling on the Injury chart.
+Treat a roll of 1-2 as knocked down, 3-5 as stunned, and 6 as out of action.</description>
+        </rule>
+        <rule name="Hired Swords" id="a252-25f6-b26d-dc3b" hidden="false">
+          <description>A Chaos Dwarf warband may hire the following Hired Swords: 
+ Ogre Bodyguard,
+ Pit Fighter,
+ Warlock,
+ Imperial Assassin,
+ and Hobgoblin Scout.
+
+
+They may hire any Hired Sword described as “all may hire,” or allowed by Orc warbands and Chaos warbands.
+They may never hire Elves of any sort!</description>
+        </rule>
+        <rule name="Indentured Servants" id="a297-b7ba-63dc-8dda" hidden="false">
+          <description>A Chaos Dwarf warband must start with at least 4 Hobgoblins; if it drops below 4 hobgoblins, you cannot recruit other members until the number of hobgoblins is increased to four or more.</description>
+        </rule>
+        <rule name="Slavers" id="c6a1-fd98-914d-1751" hidden="false">
+          <description>One of the main objectives of the Chaos Dwarves of Mordheim is to get more slaves for their sacrifices and for their tasks.
+Consequently, the Chaos Dwarves will never free any slave they capture.
+
+
+Pick one: Sacrifice them or put them to work.
+
+
+If you sacrifice them, the apprentice sorcerer will get +1 to Experience for each slave sacrificed.
+If put to work, you force them to help them in their quest for the wyrdstone; at the end of the game, gain an additional +1 wyrdstone for each working slave; then make a 1D6 roll: On a result of 2 to 6, the captive dies due to overwork, disease, the effects of long exposure to the sorcerer’s stone, or for any other similar reason, and the Chaos Dwarf band may keep the captive’s equipment.
+On a result of 1, the captive manages to escape, returns to his band with his equipment intact and, in addition, gains an experience bonus of 1D3 (if he is a henchman, simply add 1 to his total).</description>
+        </rule>
+        <rule name="Uncommon" id="2c7f-1f73-610c-099c" hidden="false">
+          <description>Chaos Dwarves are quite rare in Old World settlements.
+For this reason, when they make rolls for the acquisition of new recruits in their bands, they have to spend 1.5 times (rounding up) the amount they normally spend.
+
+
+Remember that this is not the case for Hobgoblins, a race far more common than that of Chaos Dwarves. For example, a group of Chaos Dwarf recruits armed with blunderbusses with 4 experience points would require at least 6 experience points to acquire one recruit, 12 to recruit two and so on.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="7e48-f493-c2ee-2e3d" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+  </selectionEntries>
 </catalogue>

--- a/The Restless Dead.cat
+++ b/The Restless Dead.cat
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="5d51-e8c-6ba4-d00" name="The Restless Dead (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="5d51-e8c-6ba4-d00" name="The Restless Dead (1c)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="85b9-c5d9-9e8e-7d20" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
   <selectionEntries>
-    <selectionEntry type="upgrade" import="true" name="Stash" hidden="false" id="719e-61a8-87cc-4c16" collective="false">
+    <selectionEntry type="upgrade" import="true" name="Stash" hidden="false" id="719e-61a8-87cc-4c16" collective="false" page="0">
       <constraints>
         <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="22d1-6053-ddcd-4144" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="aa93-4f85-6e09-8841" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
@@ -13,7 +13,11 @@
         <categoryLink name="Stash" hidden="false" id="1caa-825c-c81e-97d0" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="5547-b31a-c282-2950" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="5547-b31a-c282-2950" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Gold" field="name"/>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="fe6d-ccc5-4ce9-e26f" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="90e5-d76e-9268-1647" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2185,6 +2189,18 @@ Whenever the scarecrow&apos;s controller loses a wound he must pass an unmodifi
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="a0fd-318a-fc2e-49a7" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="c5fb-17fc-20bc-6fd6" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="90b0-a6ce-740c-6f9a-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="90b0-a6ce-740c-6f9a-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="29f5-43ad-48ca-95df" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Undead Equipment" id="3db-54f3-1b4f-9c09" hidden="false">
@@ -2193,7 +2209,7 @@ Whenever the scarecrow&apos;s controller loses a wound he must pass an unmodifi
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="2e2a-60fc-c03-68ca" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf" sortIndex="1"/>
             <entryLink import="true" name="Dagger" hidden="false" id="f71c-49f8-78a8-43e3" type="selectionEntry" targetId="64e0-0bb6-542b-4beb" sortIndex="2"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="8923-4936-4d19-527a" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
+            <entryLink import="true" name="Hammer" hidden="false" id="8923-4936-4d19-527a" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a" sortIndex="3">
               <modifiers>
                 <modifier type="set" value="Mace, Hammer" field="name"/>
               </modifiers>
@@ -2221,9 +2237,9 @@ Whenever the scarecrow&apos;s controller loses a wound he must pass an unmodifi
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="3033-720a-f063-ed75" hidden="false" sortIndex="3">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="2f79-4142-3f41-e3a6" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="2f79-4142-3f41-e3a6" type="selectionEntry" targetId="3d2a-426a-c350-2a03" sortIndex="1"/>
             <entryLink import="true" name="Shield" hidden="false" id="87ec-4d9d-1a6a-27ba" type="selectionEntry" targetId="74fb-cc90-1361-df26" sortIndex="3"/>
-            <entryLink import="true" name="Heavy Armor" hidden="false" id="5720-7c6e-cd48-5677" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
+            <entryLink import="true" name="Heavy Armour" hidden="false" id="5720-7c6e-cd48-5677" type="selectionEntry" targetId="4e34-bbc5-c7ef-6bd6" sortIndex="2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="2b04-b3ca-812-d86" type="selectionEntry" targetId="0871-44c2-f0f0-c27a" sortIndex="4"/>
             <entryLink import="true" name="Helmet" hidden="false" id="4e6c-f72c-beac-9e60" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2" sortIndex="5"/>
           </entryLinks>

--- a/The_Undead.cat
+++ b/The_Undead.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0b05773f-a863-7a25-f872-588b804e2c75" name="Undead (1a)" revision="6" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="0b05773f-a863-7a25-f872-588b804e2c75" name="Undead (1a)" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="888b0a33-7922-685c-49fc-591b3fb26358" name="Awakened Zombie" page="0" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -1321,6 +1321,18 @@ Dire Wolves fight with 2 attacks instead of 1 during the turn they charge.</desc
           </constraints>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="63f8-c470-00f8-18f3" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="5149-01d1-7728-af3a" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="c9af-b601-2724-34c0-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="c9af-b601-2724-34c0-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="2a53-2a10-2a38-672e" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <infoLinks>

--- a/Tomb Guardians.cat
+++ b/Tomb Guardians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="7d2b-89ab-a974-f328" name="Tomb Guardians (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="7d2b-89ab-a974-f328" name="Tomb Guardians (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="488d-4919-cbab-67d9" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -10,7 +10,7 @@
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="7d5c-8375-6ad5-7941" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" id="2c93-1b29-c17d-3d00" type="selectionEntry" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="d9e0-5145-7cb4-aa5" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" id="d9e0-5145-7cb4-aa5" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace" field="name"/>
               </modifiers>
@@ -40,7 +40,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" id="c89a-2648-5b3e-1564" hidden="false">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="3a6c-5a3-5e1d-f98e" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="3a6c-5a3-5e1d-f98e" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="380a-b8cb-bc0-987a" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -108,7 +108,7 @@ Any attack with a ranged weapon performed using these arrows benefits from a +1 
           <entryLinks>
             <entryLink import="true" name="Free Dagger" hidden="false" id="2128-55da-7c41-703a" type="selectionEntry" targetId="0d0b-ed37-d8b0-4cbf"/>
             <entryLink import="true" name="Dagger" hidden="false" id="d21b-b6e9-19a3-d53f" type="selectionEntry" targetId="64e0-0bb6-542b-4beb"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="a1ee-bebd-85aa-1c03" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a">
+            <entryLink import="true" name="Hammer" hidden="false" id="a1ee-bebd-85aa-1c03" type="selectionEntry" targetId="cfcc-39fd-aeb4-876a">
               <modifiers>
                 <modifier type="set" value="Mace, Staff" field="name"/>
               </modifiers>
@@ -750,13 +750,13 @@ Place the model anywhere within 6&quot; of the Liche Priest, but not straight in
       </profiles>
       <infoLinks>
         <infoLink name="Leader" id="9fcf-3754-28b5-901d" hidden="false" targetId="8712-d0f2-fe64-07bd" type="rule"/>
-        <infoLink name="Unknown" id="c014-7118-2dbe-28a0" hidden="false" targetId="4276-a1f7-88b6-ae4c" type="profile"/>
+        <infoLink name="Tomb Lord (Mummy) max" id="c014-7118-2dbe-28a0" hidden="false" targetId="4276-a1f7-88b6-ae4c" type="profile"/>
         <infoLink name="Fear" id="10a8-b6dd-3e92-e1d4" hidden="false" type="rule" targetId="cdc8-da3b-a2ed-d841"/>
-        <infoLink name="Unknown" id="969-37f7-6d6e-ce03" hidden="false" type="rule" targetId="114e-939e-220b-403"/>
+        <infoLink name="Immune to Psychology" id="969-37f7-6d6e-ce03" hidden="false" type="rule" targetId="114e-939e-220b-403"/>
         <infoLink name="Do not Drink" id="5b8b-d267-2d4-64c1" hidden="false" type="rule" targetId="78d7-f07e-65e2-b830"/>
         <infoLink name="No Pain" id="fef2-6a04-47da-b60a" hidden="false" type="rule" targetId="54c4-5d87-e5c5-f0dc"/>
-        <infoLink name="Immune to poison" id="6aa6-52eb-e39b-84eb" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
-        <infoLink name="May not run" id="1fec-61ae-3157-2b8c" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
+        <infoLink name="Immune to Poison" id="6aa6-52eb-e39b-84eb" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
+        <infoLink name="May not Run" id="1fec-61ae-3157-2b8c" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink name="Heroes" hidden="false" id="cc61-c674-283b-5d0d" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
@@ -800,7 +800,7 @@ Place the model anywhere within 6&quot; of the Liche Priest, but not straight in
         <entryLink import="true" name="Undead Equipment" hidden="false" id="c51e-a10f-a589-ddb2" collective="false" targetId="982b-baae-2892-3979" type="selectionEntryGroup"/>
         <entryLink import="true" name="Characteristic Increases" hidden="false" id="acf-6940-652f-a948" collective="false" targetId="7879-46ac-5598-aa00" type="selectionEntryGroup"/>
         <entryLink import="true" name="Serious Injuries" hidden="false" id="3a83-a4bf-968f-ab1c" collective="false" targetId="313b-a816-0a89-926c" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Advancement" hidden="false" id="3516-e568-d2e-da90" type="selectionEntry" targetId="c26e-414e-293-2621">
+        <entryLink import="true" name="Advancement (Hero)" hidden="false" id="3516-e568-d2e-da90" type="selectionEntry" targetId="c26e-414e-293-2621">
           <modifiers>
             <modifier type="increment" value="1" field="f983-fe4b-65c8-b54f">
               <conditions>
@@ -1066,8 +1066,8 @@ A hit from a fire-based attack will cause double the normal number of wounds o
         <infoLink name="Immune to Psychology" id="ca42-2484-949e-2689" hidden="false" type="rule" targetId="114e-939e-220b-403"/>
         <infoLink name="Do not Drink" id="6d25-5386-8959-d0c" hidden="false" type="rule" targetId="78d7-f07e-65e2-b830"/>
         <infoLink name="No Pain" id="269a-5afd-8d35-6555" hidden="false" type="rule" targetId="54c4-5d87-e5c5-f0dc"/>
-        <infoLink name="Immune to poison" id="82f5-d1d1-ea85-1e3b" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
-        <infoLink name="May not run" id="edc3-60d6-84ce-b4ac" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
+        <infoLink name="Immune to Poison" id="82f5-d1d1-ea85-1e3b" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
+        <infoLink name="May not Run" id="edc3-60d6-84ce-b4ac" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink name="Heroes" hidden="false" id="6f86-bf1d-6aa6-5bb3" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
@@ -1408,8 +1408,8 @@ A hit from a fire-based attack will cause double the normal number of wounds o
         <infoLink name="Immune to Psychology" id="9ebc-41d0-d971-8ad5" hidden="false" type="rule" targetId="114e-939e-220b-403"/>
         <infoLink name="Do not Drink" id="6ecc-da11-ac08-e16" hidden="false" type="rule" targetId="78d7-f07e-65e2-b830"/>
         <infoLink name="No Pain" id="c5df-8d1a-25c5-9b58" hidden="false" type="rule" targetId="54c4-5d87-e5c5-f0dc"/>
-        <infoLink name="Immune to poison" id="536e-5535-f22d-5303" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
-        <infoLink name="May not run" id="88a9-6911-443b-4321" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
+        <infoLink name="Immune to Poison" id="536e-5535-f22d-5303" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
+        <infoLink name="May not Run" id="88a9-6911-443b-4321" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink name="Heroes" hidden="false" id="8719-92a9-1c9b-52c5" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true"/>
@@ -1696,10 +1696,10 @@ A hit from a fire-based attack will cause double the normal number of wounds o
         <infoLink name="Do not Drink" id="2595-7ec-fbdd-e3d0" hidden="false" type="rule" targetId="78d7-f07e-65e2-b830"/>
         <infoLink name="Fear" id="b214-4bb6-1b89-9275" hidden="false" type="rule" targetId="cdc8-da3b-a2ed-d841"/>
         <infoLink name="Immune to Psychology" id="7337-dce4-256b-a334" hidden="false" type="rule" targetId="114e-939e-220b-403"/>
-        <infoLink name="Unknown" id="1bd2-c707-3c83-af4" hidden="false" type="rule" targetId="52a8-95d9-6982-5db5"/>
+        <infoLink name="No Brain" id="1bd2-c707-3c83-af4" hidden="false" type="rule" targetId="52a8-95d9-6982-5db5"/>
         <infoLink name="No Pain" id="111e-44b7-98ce-a26a" hidden="false" type="rule" targetId="54c4-5d87-e5c5-f0dc"/>
-        <infoLink name="Immune to poison" id="c869-e59e-8c54-2e2" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
-        <infoLink name="May not run" id="ab31-b55f-2929-5e1d" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
+        <infoLink name="Immune to Poison" id="c869-e59e-8c54-2e2" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
+        <infoLink name="May not Run" id="ab31-b55f-2929-5e1d" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Extra Equipment" hidden="false" id="3bbf-d395-3c3d-a1e9" collective="false">
@@ -1853,8 +1853,8 @@ A hit from a fire-based attack will cause double the normal number of wounds o
         <infoLink name="Immune to Psychology" id="afe9-ccda-b125-b16c" hidden="false" type="rule" targetId="114e-939e-220b-403"/>
         <infoLink name="No Brain" id="fb7-79f0-263-63d4" hidden="false" type="rule" targetId="52a8-95d9-6982-5db5"/>
         <infoLink name="No Pain" id="fe66-646f-d0ab-88fd" hidden="false" type="rule" targetId="54c4-5d87-e5c5-f0dc"/>
-        <infoLink name="Immune to poison" id="3292-5e8a-c9ff-2576" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
-        <infoLink name="May not run" id="10b3-964d-bdd1-4418" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
+        <infoLink name="Immune to Poison" id="3292-5e8a-c9ff-2576" hidden="false" type="rule" targetId="f654-2dea-4f11-5730"/>
+        <infoLink name="May not Run" id="10b3-964d-bdd1-4418" hidden="false" type="rule" targetId="8f9a-f7a4-45f0-6918"/>
         <infoLink name="Liche &amp; Accolyte (Mummy) max" id="2500-9035-a5f5-3c8f" hidden="false" type="profile" targetId="8bc-2e8-d672-82d4"/>
       </infoLinks>
       <selectionEntries>
@@ -2361,7 +2361,7 @@ If the chariot is hit, roll a D6 to see where it is hit: 1-2 steed, 3-4 chari
         <cost name="Warband Rating" typeId="wb-rating" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Extra Gold Cost" hidden="false" id="77ae-a4e-9947-de2d" type="selectionEntry" targetId="deca-5737-6234-23a1">
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="77ae-a4e-9947-de2d" type="selectionEntry" targetId="deca-5737-6234-23a1">
           <constraints>
             <constraint type="max" value="60" field="selections" scope="parent" shared="true" id="8e4c-4856-ad2c-e3d2" includeChildSelections="false"/>
             <constraint type="min" value="6" field="selections" scope="parent" shared="true" id="c07-2a87-1acd-500e" includeChildSelections="false"/>
@@ -2378,7 +2378,7 @@ If the chariot is hit, roll a D6 to see where it is hit: 1-2 steed, 3-4 chari
         <categoryLink name="Stash" hidden="false" id="3507-8817-d99a-4575" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="8864-7d5e-f08e-36d5" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="8864-7d5e-f08e-36d5" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="48f6-41e6-a802-efd0" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="7709-d489-f21c-438f" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2386,6 +2386,26 @@ If the chariot is hit, roll a D6 to see where it is hit: 1-2 steed, 3-4 chari
         <cost name="pts" id="3ce4-5a1d-c58d-5373" hidden="false" typeId="points" value="0"/>
         <cost name="Warband Rating" id="5bf8-9e99-5de-2367" hidden="false" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="7711-7b3d-5f0f-65b0" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="3bf9-4d65-e8eb-4377" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="79ca-cd02-dd81-97e5-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="79ca-cd02-dd81-97e5-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Home Ground" id="567e-b092-2e55-f124" hidden="false">
+          <description>The Tomb Guardians live in the Necropolises and have no trouble locating the hidden tombs in search of weapons and armor to help them defend their homes. 
+
+
+A Tomb Guardian warband always roll one extra dice in the Exploration phase.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="e48e-979e-6797-28c3" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Trantios.cat
+++ b/Trantios.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="4da7-a3e6-31d6-ec66" name="Trantios (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="4da7-a3e6-31d6-ec66" name="Trantios (1b)" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" revision="7" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="common-data" id="5e7b-bf3d-fabd-164f" targetId="e020-c282-277b-b173"/>
   </catalogueLinks>
@@ -10,7 +10,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="e158-c08a-b633-6c15" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="eb91-8acf-cc35-6cc1" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="c301-13be-9936-24ac" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="c301-13be-9936-24ac" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -36,7 +36,7 @@
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="c66f-2e58-5824-63aa" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="221e-c6f1-caee-973" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="57cb-e871-e6d2-bc90" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="57cb-e871-e6d2-bc90" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
@@ -52,7 +52,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="8548-813e-4a7f-83b1" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="7d25-1f9f-3311-993" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="7d25-1f9f-3311-993" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Helmet" hidden="false" id="eb1f-c252-c872-1203" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
           </entryLinks>
         </selectionEntryGroup>
@@ -64,7 +64,7 @@
           <entryLinks>
             <entryLink import="true" name="Dagger" hidden="false" id="bbeb-30fa-c9fd-8f" collective="false" targetId="64e0-0bb6-542b-4beb" type="selectionEntry"/>
             <entryLink import="true" name="Free Dagger" hidden="false" id="27fc-cae9-3751-4374" collective="false" targetId="0d0b-ed37-d8b0-4cbf" type="selectionEntry"/>
-            <entryLink import="true" name="Hammer, staff, mace or club" hidden="false" id="1073-8a57-754d-75d7" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
+            <entryLink import="true" name="Hammer" hidden="false" id="1073-8a57-754d-75d7" collective="false" targetId="cfcc-39fd-aeb4-876a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" value="Hammer, Mace" field="name"/>
               </modifiers>
@@ -96,7 +96,7 @@
         <selectionEntryGroup name="Missile Weapons" hidden="false" id="2bf3-19cb-cf93-f997" collective="false" import="true">
           <entryLinks>
             <entryLink import="true" name="Pistol" hidden="false" id="71e2-f01e-ec8e-bcce" collective="false" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-            <entryLink import="true" name="Dueling Pistol" hidden="false" id="d541-e7e1-a412-590e" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
+            <entryLink import="true" name="Duelling Pistol" hidden="false" id="d541-e7e1-a412-590e" type="selectionEntry" targetId="da24-6a7f-725b-5bcb">
               <modifiers>
                 <modifier type="set" value="25" field="points"/>
               </modifiers>
@@ -110,7 +110,7 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Armor" hidden="false" id="96ec-9fd8-29d0-f9dc" collective="false" import="true">
           <entryLinks>
-            <entryLink import="true" name="Light Armor" hidden="false" id="2950-b8db-aafa-cccd" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
+            <entryLink import="true" name="Light Armour" hidden="false" id="2950-b8db-aafa-cccd" type="selectionEntry" targetId="3d2a-426a-c350-2a03"/>
             <entryLink import="true" name="Shield" hidden="false" id="4e4c-ae5-bdf3-5afe" type="selectionEntry" targetId="74fb-cc90-1361-df26"/>
             <entryLink import="true" name="Helmet" hidden="false" id="ab5c-ade8-700-be83" type="selectionEntry" targetId="d0e5-ca89-5f0d-f5d2"/>
             <entryLink import="true" name="Buckler" hidden="false" id="54c4-7772-5284-da78" type="selectionEntry" targetId="0871-44c2-f0f0-c27a"/>
@@ -2435,7 +2435,7 @@ The Duellist counts as using a shield in close combat.</description>
         <categoryLink name="Stash" hidden="false" id="dfe8-fab2-5e81-9b4d" targetId="a31acb39-8ce9-d6d7-bcc9-f3144d63db48" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink import="true" name="Gold" hidden="false" id="eeb9-3a9f-cae6-fd38" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
+        <entryLink import="true" name="Variable Gold Cost" hidden="false" id="eeb9-3a9f-cae6-fd38" collective="false" targetId="deca-5737-6234-23a1" type="selectionEntry"/>
         <entryLink import="true" name="Wyrdstone" hidden="false" id="ecf0-411a-6eef-772" collective="false" targetId="60f8-e6e7-c2ea-0dad" type="selectionEntry"/>
         <entryLink import="true" name="Equipment" hidden="false" id="73c0-dc11-a737-5d32" collective="false" targetId="2247-1f56-bc59-0ead" type="selectionEntryGroup"/>
       </entryLinks>
@@ -2443,6 +2443,35 @@ The Duellist counts as using a shield in close combat.</description>
         <cost name="pts" hidden="false" id="2a7d-93f6-f616-562a" typeId="points" value="0"/>
         <cost name="Warband Rating" hidden="false" id="294-af54-854e-ac6c" typeId="wb-rating" value="0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="d975-f313-a175-6b87" page="0">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="d462-96bb-daee-968b" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="c06b-60fc-596d-5570-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="c06b-60fc-596d-5570-max" includeChildSelections="false"/>
+      </constraints>
+      <rules>
+        <rule name="Hired Swords" id="c393-4e8f-ed48-705f" hidden="false">
+          <description>A Tilean warband can use any Hired Sword available to the Mercenary warbands including the following
+
+
+ - Shadow Warrior
+ - Big Game Hunter
+ - Expert Marksman
+
+
+Unless noted otherwise, Hired Swords cannot benefit from individual city-state rules given to each warband.</description>
+        </rule>
+        <rule name="Trantio Extra Gold" id="4358-2cf6-9607-a555" hidden="false">
+          <description>A warband hailing from Trantio will be the best-equipped and most experienced human warband in Lustria.
+To represent this a Trantio war band will always start a one-off match with an extra 20% gc and in a Lustrian campaign they will start with an extra 100 gc added to their total.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="0709-7220-a6b4-6ca6" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Witch_Hunters.cat
+++ b/Witch_Hunters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="65788600-7fa0-eb7c-b1a3-36d0c3c506c6" name="Witch Hunters (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="65788600-7fa0-eb7c-b1a3-36d0c3c506c6" name="Witch Hunters (1a)" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue" page="0">
   <selectionEntries>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Flagellants" page="0" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -1341,6 +1341,18 @@
           </conditions>
         </modifier>
       </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Warband Rules" hidden="false" id="d053-8202-cc68-7c46">
+      <categoryLinks>
+        <categoryLink name="Configuration" hidden="false" id="c675-ba41-279d-f619" targetId="4852-c4cb-82b0-b7fa" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="force" shared="true" id="19b0-0a2f-4065-3e77-min" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="19b0-0a2f-4065-3e77-max" includeChildSelections="false"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="EXP advancement" id="eb19-ee6b-5b78-6add" hidden="false" targetId="525a-8370-3dd1-ff3d" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </selectionEntries>
   <infoLinks>

--- a/common-data.cat
+++ b/common-data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e020-c282-277b-b173" name="common-data" revision="21" battleScribeVersion="2.03" library="true" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="e020-c282-277b-b173" name="common-data" revision="22" battleScribeVersion="2.03" library="true" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry id="d769-0d85-e810-df60" name="Experience" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
@@ -242,6 +242,11 @@ Warhorses only.</description>
           </conditions>
         </modifier>
       </modifiers>
+      <rules>
+        <rule name="Sword and Buckler" id="0504-e341-08e4-78d6" hidden="false">
+          <description>If your model is armed with a buckler and a sword, you may re-roll any failed parries once. A model armed with two swords can still only roll once.</description>
+        </rule>
+      </rules>
     </selectionEntry>
     <selectionEntry id="4c6d-eb92-53a7-a6d3" name="Gromril Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -1637,6 +1642,14 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <rule id="81a5-4dbc-dd19-aef3" name="Rarity" hidden="false">
           <description>Rarity 9</description>
         </rule>
+        <rule name="Hand-to-hand" id="a8a0-16f3-34e9-76ed" hidden="false" page="0">
+          <description>Pistols can be used in hand-to-hand combat as well as for shooting. A model armed with a pistol and another close combat weapon gains +1 Attack, which is resolved at Strength 4 with a -2 save modifier. This bonus attack can be used only once per combat. If you are firing a brace of pistols, your model can fight with 2 Attacks in the first turn of close combat. These attacks are resolved with a model’s Weapon Skill like any normal close combat attack and likewise may be parried. Successful hits are resolved at Strength 4 and with
+a -2 save modifier, regardless of the firer’s Strength.</description>
+        </rule>
+        <rule name="Shoot In Hand-To-Hand Combat" id="8906-d783-a9d8-3a6a" hidden="false">
+          <description>A model armed with a crossbow pistol may shoot it in the first round of a hand-to-hand combat and this shot is always resolved first, before any blows are struck. This shot has an extra -2 to hit penalty. Use model&apos;s Ballistic Skill to see whether it hits or not.
+Note: No matter if its a brace or not you only get 1 shot.</description>
+        </rule>
       </rules>
       <costs>
         <cost name=" gc" typeId="points" value="35"/>
@@ -1644,7 +1657,7 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <constraints>
-        <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="6eba-986e-1a07-0e58"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6eba-986e-1a07-0e58"/>
       </constraints>
       <modifiers>
         <modifier type="increment" value="35" field="points">
@@ -1658,6 +1671,19 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
           </conditions>
         </modifier>
       </modifiers>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Brace" hidden="false" id="a2c7-0fe2-a068-de0b">
+          <infoLinks>
+            <infoLink name="Brace" id="544b-f913-5f46-9186" hidden="false" type="rule" targetId="a67f-510b-c01b-8c72"/>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" value="35" field="points"/>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="895e-3ecf-3daf-36d6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
     <selectionEntry id="da24-6a7f-725b-5bcb" name="Duelling Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -1692,7 +1718,7 @@ a duelling pistol have a +1 bonus to hit.</description>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <constraints>
-        <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="d684-25ed-f53c-1219"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d684-25ed-f53c-1219"/>
       </constraints>
       <modifiers>
         <modifier type="increment" value="30" field="points">
@@ -1706,6 +1732,19 @@ a duelling pistol have a +1 bonus to hit.</description>
           </conditions>
         </modifier>
       </modifiers>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Brace" hidden="false" id="a4b1-781f-add0-8678">
+          <infoLinks>
+            <infoLink name="Brace" id="3369-6664-5fc4-6011" hidden="false" type="rule" targetId="a67f-510b-c01b-8c72"/>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" value="30" field="points"/>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="bdc1-ed11-ccb7-b868" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
     <selectionEntry id="e2c2-751b-5384-ce1d" name="Elf Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -1876,7 +1915,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <constraints>
-        <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="bd8d-028e-ccb8-f783"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bd8d-028e-ccb8-f783"/>
       </constraints>
       <modifiers>
         <modifier type="increment" value="15" field="points">
@@ -1890,6 +1929,19 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
           </conditions>
         </modifier>
       </modifiers>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Brace" hidden="false" id="ae20-29a5-5bfc-afe3">
+          <infoLinks>
+            <infoLink name="Brace" id="a222-35ff-f83f-9445" hidden="false" type="rule" targetId="a67f-510b-c01b-8c72"/>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" value="15" field="points"/>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="0832-9bfc-6f8d-75d0" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
     <selectionEntry id="a802-b7c6-caea-a5b1" name="Repeater Crossbow" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -2726,7 +2778,7 @@ Only available to Humans.</description>
 a -2 save modifier, regardless of the firer’s Strength.</description>
         </rule>
         <rule id="0c3f-75f6-646f-71ad" name="Rarity" hidden="false">
-          <description>Rarity 10</description>
+          <description>Rarity 9</description>
         </rule>
       </rules>
       <infoLinks>
@@ -2734,12 +2786,12 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         <infoLink id="2794-a9df-e85e-86aa" name="Firearm save modifier" hidden="false" targetId="5d21-2b30-4219-ec86" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name=" gc" typeId="points" value="30"/>
+        <cost name=" gc" typeId="points" value="25"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <constraints>
-        <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="08d4-6287-7c20-78b0"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="08d4-6287-7c20-78b0"/>
       </constraints>
       <modifiers>
         <modifier type="increment" value="25" field="points">
@@ -2762,6 +2814,24 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
           </conditionGroups>
         </modifier>
       </modifiers>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Brace" hidden="false" id="f3b7-8fca-a58c-713a">
+          <infoLinks>
+            <infoLink name="Brace" id="cda4-027b-809b-6bde" hidden="false" type="rule" targetId="a67f-510b-c01b-8c72"/>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" value="21" field="points"/>
+          </modifiers>
+          <rules>
+            <rule name="Rarity" id="8ab2-8fbc-3cd0-f8dc" hidden="false">
+              <description>Rarity 10</description>
+            </rule>
+          </rules>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="421e-afa4-e68c-df6e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
     <selectionEntry id="5fd9-080e-10f1-9d52" name="Double Barreled Hochland Long Rifle" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <profiles>
@@ -3930,7 +4000,7 @@ Toughened leathers cannot be sold back at the Trading Posts; the stench alone is
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry id="c26e-414e-293-2621" name="Advancement (Hero)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c26e-414e-293-2621" name="Advancement (Hero)" hidden="false" collective="false" import="true" type="upgrade" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a79c-4fb2-4100-9f13" type="max"/>
       </constraints>
@@ -4098,7 +4168,7 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry id="583e-a0c5-873-acdc" name="Advancement (Henchmen)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="583e-a0c5-873-acdc" name="Advancement (Henchmen)" hidden="false" collective="false" import="true" type="upgrade" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8c2-da7f-edc5-5630" type="max"/>
       </constraints>
@@ -5063,7 +5133,7 @@ Not available to Possessed or Undead.</description>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="df9d-8724-d362-9d7c" name="Academic Skills" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="df9d-8724-d362-9d7c" name="Academic Skills" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c69-fc2a-5033-ebcf" type="min"/>
       </constraints>
@@ -5454,7 +5524,7 @@ This counts as an academic skill.</description>
         <entryLink id="1d4b-f425-6e4c-b130" name="+1 WS" hidden="false" collective="false" import="true" targetId="7418-394e-fe13-2a96" type="selectionEntry" sortIndex="2"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="ee2c-89e3-489b-d0cb" name="Combat Skills" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="ee2c-89e3-489b-d0cb" name="Combat Skills" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b43e-f5a8-b370-a340" type="min"/>
       </constraints>
@@ -5552,7 +5622,7 @@ only applies when they are armed with normal swords or weeping blades, and not w
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="0073-d2d6-15c0-45b1" name="Shooting Skills" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="0073-d2d6-15c0-45b1" name="Shooting Skills" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="430e-dad9-a668-235c" type="min"/>
       </constraints>
@@ -5680,7 +5750,7 @@ with a bow or crossbow (but not a crossbow pistol).</description>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="e134-0fdf-67a2-4684" name="Speed Skills" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="e134-0fdf-67a2-4684" name="Speed Skills" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ef7-5338-d8ef-cad0" type="min"/>
       </constraints>
@@ -5795,7 +5865,7 @@ charging), the order of attack between the charger(s) and the warrior with this 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="e5ac-cd5b-9057-e096" name="Strength Skills" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="e5ac-cd5b-9057-e096" name="Strength Skills" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eb1d-d235-c34f-c0c4" type="min"/>
       </constraints>
@@ -5900,7 +5970,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="975d-a3e5-9029-58d5" name="Armour" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="975d-a3e5-9029-58d5" name="Armour" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb13-71da-4b4e-deac" type="min"/>
       </constraints>
@@ -5916,7 +5986,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         <entryLink id="bc00-e905-1ad2-3a16" name="Toughened Leathers" hidden="false" collective="false" import="true" targetId="439f-1b4d-1579-14b" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="073c-d5ce-dcc0-b820" name="Hand to Hand Weapons" hidden="false" collective="false" import="true" collapsible="false">
+    <selectionEntryGroup id="073c-d5ce-dcc0-b820" name="Hand to Hand Weapons" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="70e0-a7b1-cc1f-5995" type="min"/>
       </constraints>
@@ -5944,9 +6014,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         <entryLink import="true" name="Sword Breaker" hidden="false" id="3721-1714-d050-1eb2" type="selectionEntry" targetId="719a-cf09-5749-6be2">
           <rules>
             <rule name="Trap Blade:" id="8f39-fb0c-60ae-dbf4" hidden="false">
-              <description>The two prongs used to trap an opponent&apos;s weapon are snapped out when the warrior parries. Whenever you make a successful parry attempt roll a D6. If you score a 4+ you break the weapon your opponent was using. The weapon is now useless and they must use another one, or if they have no other weapon, resort to unarmed combat.
-
-</description>
+              <description>The two prongs used to trap an opponent&apos;s weapon are snapped out when the warrior parries. Whenever you make a successful parry attempt roll a D6. If you score a 4+ you break the weapon your opponent was using. The weapon is now useless and they must use another one, or if they have no other weapon, resort to unarmed combat.</description>
             </rule>
           </rules>
           <modifiers>
@@ -6185,7 +6253,7 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
         <entryLink import="true" name="Weeping Blades" hidden="false" id="d77d-47a7-1215-e1cc" type="selectionEntry" targetId="0a36-4063-32b7-61b3"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="1937-df4f-3c68-e0be" name="Missile Weapons" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="1937-df4f-3c68-e0be" name="Missile Weapons" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7f8-e6d1-34c6-505e" type="min"/>
       </constraints>
@@ -6506,13 +6574,13 @@ must retire from the warband.</description>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="70b9-9a07-4088-7598" name="Skills" hidden="false" collective="false" import="true" collapsible="true">
+    <selectionEntryGroup id="70b9-9a07-4088-7598" name="Skills" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4884-6328-6974-bafb" type="max"/>
         <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="08b8-7efb-cf23-0534" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="955a-d5d9-dfa2-b7ed" name="Academic Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="3" collapsible="false">
+        <selectionEntry id="955a-d5d9-dfa2-b7ed" name="Academic Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="3" collapsible="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3343-7d3b-63c5-11d1" type="max"/>
           </constraints>
@@ -6525,7 +6593,7 @@ must retire from the warband.</description>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="46be-0b42-069c-bea9" name="Combat Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="1" collapsible="false">
+        <selectionEntry id="46be-0b42-069c-bea9" name="Combat Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="1" collapsible="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e945-d9f7-3271-3511" type="max"/>
           </constraints>
@@ -6538,7 +6606,7 @@ must retire from the warband.</description>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9ff6-272c-433e-704f" name="Shooting Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="2" collapsible="false">
+        <selectionEntry id="9ff6-272c-433e-704f" name="Shooting Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="2" collapsible="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="decd-aef4-71ae-c2b3" type="max"/>
           </constraints>
@@ -6551,7 +6619,7 @@ must retire from the warband.</description>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a354-8274-2d13-2ba4" name="Speed Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="5" collapsible="false">
+        <selectionEntry id="a354-8274-2d13-2ba4" name="Speed Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="5" collapsible="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="122c-9010-b239-a4e2" type="max"/>
           </constraints>
@@ -6564,7 +6632,7 @@ must retire from the warband.</description>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c736-d3a0-629d-0631" name="Strength Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="4" collapsible="false">
+        <selectionEntry id="c736-d3a0-629d-0631" name="Strength Skills" hidden="false" collective="false" import="true" type="upgrade" sortIndex="4" collapsible="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca32-c763-3d0b-3356" type="max"/>
           </constraints>
@@ -6579,7 +6647,7 @@ must retire from the warband.</description>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="a2cf-6f28-f7c2-275d" name="Miscellaneous Equipment" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="a2cf-6f28-f7c2-275d" name="Miscellaneous Equipment" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4aa1-2ce5-e554-edc6" type="min"/>
       </constraints>
@@ -6653,7 +6721,7 @@ Multiple models that have the horn cannot force a second re-roll. (Piranha warri
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="5541-f5c4-85e0-b399" name="Mutations" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="5541-f5c4-85e0-b399" name="Mutations" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d97-52b6-3a7f-50a3" type="min"/>
       </constraints>
@@ -6780,7 +6848,7 @@ for details.</description>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="61c7-8179-00b5-1772" name="Chaos Rituals" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="61c7-8179-00b5-1772" name="Chaos Rituals" hidden="false" collective="false" import="true" collapsible="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e287-19d3-4453-1942" type="min"/>
       </constraints>
@@ -6895,7 +6963,7 @@ If he engages a fleeing enemy, in the close combat phase he will score one autom
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="3905-cd06-b0b9-95d3" name="Prayers of Taal" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="3905-cd06-b0b9-95d3" name="Prayers of Taal" hidden="false" collective="false" import="true" collapsible="true">
       <selectionEntries>
         <selectionEntry id="bc04-35b-654d-279a" name="1 - Stag&apos;s Leap" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
@@ -7018,7 +7086,7 @@ No armour saves allowed.</characteristic>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="9614-2638-4e92-128d" name="Cavalry Skills" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="9614-2638-4e92-128d" name="Cavalry Skills" hidden="false" collective="false" import="true" collapsible="true">
       <selectionEntries>
         <selectionEntry id="f95d-1030-4a88-6824" name="Ride" hidden="false" collective="false" import="true" type="upgrade" sortIndex="1">
           <constraints>
@@ -7308,7 +7376,7 @@ no longer frenzied. He continues to fight as normal for the rest of the battle.<
       <description>You may not move and fire a  in the same turn, other than to pivot on the spot to face your target or stand up.</description>
     </rule>
     <rule id="17dc-9c49-08e1-af45" name="Parry" page="0" hidden="false">
-      <description>The two prongs used to trap an opponent&apos;s weapon are snapped out when the warrior parries. Whenever you make a successful parry attempt roll a D6. If you score a 4+ you break the weapon your opponent was using. The weapon is now useless and they must use another one, or if they have no other weapon, resort to unarmed combat.</description>
+      <description>When an opponent scores a hit, Roll a D6. If the score is higher than the number your opponent rolled to hit, the buckler or sword has parried the strike. Note that it is therefore impossible to parry a blow which scored a 6 on the roll to hit.</description>
     </rule>
     <rule id="4f7f-29ec-a9da-82fc" name="Prepare shot" page="0" hidden="false">
       <description>Takes a whole turn to reload, so you may only fire every other turn. If you have a brace of pistols (ie, two) you may fire every turn.</description>
@@ -7465,6 +7533,9 @@ If the extra move takes the Orc or Goblin warrior within charge reach of an enem
     </rule>
     <rule id="52a8-95d9-6982-5db5" name="No Brain" hidden="false">
       <description>This creature has no intelligence and as such never gains experience.</description>
+    </rule>
+    <rule name="Brace" id="a67f-510b-c01b-8c72" hidden="false">
+      <description>Allows 2 pistols to be taken as 1 missile option</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
This fixed the following:
Brace - Any pistols using common ref to do braces so your cap of missile weapons don't over flow
Stash - Renamed the Variable Gold to Gold
Config - Added a mandatory Warband Rules so the player knows the experience chart and any other special rules that apply to them
Parry rule - on bucklers had to be fixed and added extra bit for swords in a new rule on buckler
Drop-down menus - all common used menus (skills and such) now should be dropdowns
Treasure Dwarfs - Gromil armor is now at right cost in the equipment but didn't fix the weapon issue with this.