### PR TITLE
Fix chorf henchmen costs and equipment limits

### DIFF
--- a/Sons of Hashut.cat
+++ b/Sons of Hashut.cat
@@ -96,7 +96,7 @@ They may never hire Elves of any sort!</description>
       </selectionEntryGroups>
       <constraints>
         <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="d654-85da-1ece-54f4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f1a9-7c95-2f75-7afc" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f1a9-7c95-2f75-7afc" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
       </constraints>
     </selectionEntryGroup>
     <selectionEntryGroup name="Special Skills (Chaos Dwarf)" id="672e-b1a1-f020-85dd" hidden="false" collective="false" import="true" collapsible="true">
@@ -212,7 +212,7 @@ They may never hire Elves of any sort!</description>
       </selectionEntryGroups>
       <constraints>
         <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="6424-f59d-dc61-456b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="aac6-c570-811a-10a6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="aac6-c570-811a-10a6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
       </constraints>
     </selectionEntryGroup>
     <selectionEntryGroup name="Starting Equipment (Hobgoblin)" id="8363-3699-3e00-a346" hidden="false">
@@ -264,7 +264,7 @@ They may never hire Elves of any sort!</description>
       </selectionEntryGroups>
       <constraints>
         <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="aa4d-5696-ff81-0166" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="03ce-112a-0228-9309" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="03ce-112a-0228-9309" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>

--- a/Sons of Hashut.cat
+++ b/Sons of Hashut.cat
@@ -1153,7 +1153,7 @@ Remember that this is not the case for Hobgoblins, a race far more common than t
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Chaos Dwarf Warrior" hidden="false" id="92fc-e833-45bb-f83c" sortIndex="1">
           <costs>
-            <cost name=" gc" typeId="points" value="40"/>
+            <cost name=" gc" typeId="points" value="0"/>
             <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
@@ -1319,7 +1319,7 @@ Remember that this is not the case for Hobgoblins, a race far more common than t
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Blunderbuss Chaos Dwarf" hidden="false" id="c862-37d4-0c9f-9b53" sortIndex="1">
           <costs>
-            <cost name=" gc" typeId="points" value="40"/>
+            <cost name=" gc" typeId="points" value="0"/>
             <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>
@@ -1484,7 +1484,7 @@ Remember that this is not the case for Hobgoblins, a race far more common than t
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Hobgoblin" hidden="false" id="ccb3-c2a2-f240-f67f" sortIndex="1">
           <costs>
-            <cost name=" gc" typeId="points" value="15"/>
+            <cost name=" gc" typeId="points" value="0"/>
             <cost name=" Warband Rating" typeId="wb-rating" value="5"/>
             <cost name=" Rarity" typeId="rarity" value="0"/>
           </costs>


### PR DESCRIPTION
Updated maximum on starting equipment from 1 to unlimited.
Removed the container costs for henchmen.