### PR TITLE
Added more fixes

### DIFF
--- a/Beastmen_Raiders.cat
+++ b/Beastmen_Raiders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e783-91c9-0f57-a7bb" name="Beastmen Raiders (1a)" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="e783-91c9-0f57-a7bb" name="Beastmen Raiders (1a)" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="b758-ee46-f27e-58dd" name="Beastman Rules" shortName="Beastman" publisher="https://broheim.net/downloads/warbands/unofficial/Beastmen%2C%20Errata%27d.pdf" publisherUrl="https://broheim.net/downloads/warbands/unofficial/Beastmen%2C%20Errata%27d.pdf"/>
   </publications>
@@ -1269,12 +1269,15 @@ If an Ungor rolls ‘That lad’s got talent’ it must be re-rolled.</descripti
         <cost name="Warband Rating" typeId="wb-rating" value="5"/>
       </costs>
       <constraints>
-        <constraint type="max" value="10" field="selections" scope="roster" shared="false" id="fe4d-b148-7095-426e" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+        <constraint type="max" value="5" field="selections" scope="parent" shared="false" id="1a6c-a44f-5a6f-3f2c" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8550-3c54-3cff-edaa"/>
       </constraints>
     </selectionEntry>
     <selectionEntry id="f882-12d0-ce5c-f7c1" name="Gor" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dba6-c9f9-d647-200e" type="max"/>
+        <constraint type="max" value="5" field="selections" scope="parent" shared="false" id="5e58-515a-1bfa-68e7" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ef73-8cdd-c369-5f0c"/>
       </constraints>
       <profiles>
         <profile id="4ce3-0df4-7fde-d4c0" name="Gor" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">
@@ -1588,6 +1591,7 @@ If an Ungor rolls ‘That lad’s got talent’ it must be re-rolled.</descripti
     <selectionEntry id="3da6-37c6-6fd0-c92f" name="Minotaur" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3059-f02c-3471-4848" type="max"/>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b6c0-d072-f045-b4e9"/>
       </constraints>
       <profiles>
         <profile id="f559-c836-bb3c-fdb4" name="Minotaur" hidden="false" typeId="e1beaa44-e54d-dd6b-d1f2-446b333c9bb9" typeName="Model">

--- a/Kislevites.cat
+++ b/Kislevites.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9632-7414-5d8a-43cd" name="Kislevites (1a)" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="9632-7414-5d8a-43cd" name="Kislevites (1a)" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <publications>
     <publication id="5164-95fd-8401-79b9" name="Kislevites Rules" shortName="Kislevites" publisher="https://broheim.net/downloads/warbands/official/Kislevites.pdf" publisherUrl="https://broheim.net/downloads/warbands/official/Kislevites.pdf"/>
   </publications>
@@ -2310,6 +2310,16 @@ Until the item is replaced, the Captain suffers a -1 penalty to all tests and ro
                 <condition field="selections" scope="self" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="054e-708c-6d78-a766" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="set" value="25" field="points">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="a4b1-781f-add0-8678" shared="true" childName="Brace"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" value="30" field="points">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="parent" childId="a4b1-781f-add0-8678" shared="true" childName="Brace"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <entryLinks>
             <entryLink id="ea74-9daa-52dd-0ed6" name="Inheritance" hidden="false" collective="false" import="true" targetId="054e-708c-6d78-a766" type="selectionEntry"/>
@@ -2320,14 +2330,6 @@ Until the item is replaced, the Captain suffers a -1 penalty to all tests and ro
     <selectionEntryGroup id="6b13-7b10-e009-f519" name="Armor" hidden="false" collective="false" import="true">
       <entryLinks>
         <entryLink id="959c-b9e6-9872-b805" name="Buckler" hidden="false" collective="false" import="true" targetId="0871-44c2-f0f0-c27a" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="points" value="3">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc6-20c2-34ee-759a" type="instanceOf"/>
-                <condition field="selections" scope="self" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="054e-708c-6d78-a766" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <entryLinks>
             <entryLink id="0a1f-7363-5cca-05a1" name="Inheritance" hidden="false" collective="false" import="true" targetId="054e-708c-6d78-a766" type="selectionEntry"/>
           </entryLinks>
@@ -2398,7 +2400,20 @@ Until the item is replaced, the Captain suffers a -1 penalty to all tests and ro
         <entryLink id="1da3-9476-5ac0-3a0b" name="Bow" hidden="false" collective="false" import="true" targetId="311a-bf3f-67ff-46e7" type="selectionEntry"/>
         <entryLink id="405d-ef6b-903f-3ed9" name="Crossbow" hidden="false" collective="false" import="true" targetId="38cc-bc0b-7f19-8039" type="selectionEntry"/>
         <entryLink id="12c6-3917-3ea4-5c11" name="Pistol" hidden="false" collective="false" import="true" targetId="67e9-a4f5-8f76-168c" type="selectionEntry"/>
-        <entryLink id="7218-b2d7-94d8-846f" name="Duelling Pistol" hidden="false" collective="false" import="true" targetId="da24-6a7f-725b-5bcb" type="selectionEntry"/>
+        <entryLink id="7218-b2d7-94d8-846f" name="Duelling Pistol" hidden="false" collective="false" import="true" targetId="da24-6a7f-725b-5bcb" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="25" field="points">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="parent" childId="a4b1-781f-add0-8678" shared="true" childName="Brace"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" value="30" field="points">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="parent" childId="a4b1-781f-add0-8678" shared="true" childName="Brace"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
         <entryLink id="0bcc-fd7b-be87-c91b" name="Handgun" hidden="false" collective="false" import="true" targetId="7f5a-d04d-153d-d334" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>

--- a/Possessed.cat
+++ b/Possessed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="39bde8be-ab13-2d3c-098b-1d52b4cbbf63" name="Cult of the Possessed (Core)" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="39bde8be-ab13-2d3c-098b-1d52b4cbbf63" name="Cult of the Possessed (Core)" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <selectionEntries>
     <selectionEntry id="074d9cc5-ab18-5302-91eb-29f4f9d61bcc" name="Beastmen" page="0" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -1390,7 +1390,7 @@ They automatically pass any Leadership tests they are required to take.</descrip
       </profiles>
       <infoLinks>
         <infoLink id="c6a4d5fa-343c-3dba-da8e-93c2e602551f" name="Mutations" hidden="false" targetId="75a2f07b-eab8-01aa-de76-d15f38bfb34e" type="rule"/>
-        <infoLink id="df0e419c-d3d1-bd88-6423-ebeaa2a01dc8" name="Fear" hidden="false" targetId="4390265d-0892-5427-fe46-78054de59a7e" type="rule"/>
+        <infoLink id="df0e419c-d3d1-bd88-6423-ebeaa2a01dc8" name="Fear" hidden="false" targetId="cdc8-da3b-a2ed-d841" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="83ab8692-01da-65c5-af52-a55d4800f012-a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" hidden="false" targetId="a0fce0bc-02e0-a064-7a39-5b97ff8a9c94" primary="true" name="Heroes"/>
@@ -1853,96 +1853,12 @@ If he engages a fleeing enemy, in the close combat phase he will score one autom
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="c03b3d4d-30bf-c3b6-4992-b0b5b5ef9617" name="+1 Enemy armour save:" page="0" hidden="false">
-      <description>An enemy wounded by a dagger gains a +1 bonus to his armour save, and a 6+ armour save if he normally has none.</description>
-    </rule>
-    <rule id="3207d292-6501-25cb-d869-63b0987c78f6" name="Avoid stun:" page="0" hidden="false">
-      <description>A model that is equipped with a helmet has a special 4+ save on a D6 against being stunned. If the save is made, treat the stunned
-result as knocked down instead. This save is not modified by the opponent’s Strength.</description>
-    </rule>
-    <rule id="c0c80c24-1dc8-7adc-c069-8917b30bffcd" name="Cavalry bonus" page="0" hidden="false">
-      <description>If using the rules for mounted models, a mounted warrior armed with a spear receives a   Strength bonus when he charges. This bonus only applies for that turn.</description>
-    </rule>
-    <rule id="3f6ce5a7-906d-b980-439f-9dd32ad84ed5" name="Cavalry Weapon" page="0" hidden="false">
-      <description>A warrior must own a warhorse to use , as it can only be used whilst he is on horseback.</description>
-    </rule>
-    <rule id="47cdbf9b-babf-aefa-1d8a-cac5b85bf281" name="ConCussion" page="0" hidden="false">
-      <description>Hammers and other bludgeoning weapons are excellent to use for striking your enemy senseless. When using a hammer, club or mace, a roll of 2-4 is treated as stunned when rolling to see the extent of a model’s injuries.</description>
-    </rule>
-    <rule id="6118263e-03c4-68f7-694d-6ceebac4e80b" name="Cutting edge" page="0" hidden="false">
-      <description>A Cutting edgee has an extra save modifier of -1, so a model with Strength 4 using an Cutting edge has a -2 save modifier when he hits an opponent in hand-to-hand combat.</description>
-    </rule>
-    <rule id="140e74d1-bf16-356b-c7d1-08b3bb5052b5" name="Difficult To Use" page="0" hidden="false">
-      <description>A model with aDifficult To Use  may not use a second weapon or buckler in his other hand because it requires all his skill to wield it. He may carry a shield as normal though.</description>
-    </rule>
     <rule id="bd2100cc-65f9-2311-e4b9-d0e6830884c3" name="EXP Adancement" page="0" hidden="false">
       <description>Heroes get new advances at 2, 4, 6, 8, 11, 14, 17, 20, 24, 28, 32, 36, 41, 46, 51, 57, 63, 69, 76, 83 and 90 experience.
 Henchmen and Hired Swords get new advances at 2, 5, 9 and 14 experience.</description>
     </rule>
-    <rule id="4390265d-0892-5427-fe46-78054de59a7e" name="Fear" page="0" hidden="false">
-      <description>A model must take a Fear test (ie, test against his Leadership) in the following situations. 
-Note that creatures that cause fear can ignore these tests.
-a) If the model is charged by a warrior or a creature which causes fear. If a warrior is charged by an enemy that he fears then he must take a test to overcome that fear. Test when the charge is declared and is determined to be within range. If the test is passed the model may fight as normal. If it is failed, the model must roll 6s to score hits in that round of combat.
-b) If the model wishes to charge a fearcausing enemy. If a warrior wishes to charge an enemy that it fears then it must take a test to overcome this. If it fails the model may not charge and must remain stationary for the turn. Treat this as a failed charge.</description>
-    </rule>
-    <rule id="abb6f4c1-7058-c49a-c0df-9dfacb18d599" name="Frenzy" page="0" hidden="false">
-      <description>Frenzied models must always charge if there are any enemy models within charge range (check after charges have been declared). The player has no choice in this matter – the warrior will automatically declare a charge. Frenzied warriors fight with double their Attacks characteristic in hand-to-hand combat. Warriors with 1 Attack therefore have 2 Attacks, warriors with 2
-Attacks have 4, etc. If a warrior is carrying a weapon in each hand, he receives +1 Attack for this as normal. This extra Attack is not doubled. Once they are within charge range, frenzied warriors are immune to all other psychology, such as fear and don’t have to take these tests as long as they remain within charge range. If a frenzied model is knocked down or stunned, he is
-no longer frenzied. He continues to fight as normal for the rest of the battle.</description>
-    </rule>
-    <rule id="6549136a-9a00-4d3a-b8fa-ecadf63e4744" name="Gromril weapon" page="0" hidden="false">
-      <description>A gromril weapon has an extra -1 save modifier, and costs four times the price of a normal weapon of its kind.</description>
-    </rule>
-    <rule id="a3327e94-8ff2-b189-9303-34c54c57373f" name="Gun Save modifier" page="0" hidden="false">
-      <description>even better at penetrating armour than their Strength  suggests. A warrior wounded by afirearm lmust make his armour save with a -2 modifier.</description>
-    </rule>
-    <rule id="3ebe96a5-ad6a-b51d-0d99-f62dfb2a807c" name="Hatred" page="0" hidden="false">
-      <description>Warriors who fight enemies they hate in hand-to-hand combat may re-roll any misses when they attack in the first turn of each hand-to-hand combat. This bonus applies only in the first turn of each combat</description>
-    </rule>
-    <rule id="441f52ae-32a2-44f9-1784-c76c65bfd452" name="Heavy" page="0" hidden="false">
-      <description>The weapon is extremely tiring to use, so its +1 Strength bonus applies only in the first turn of each hand-to-hand combat.</description>
-    </rule>
-    <rule id="05584e01-dfb3-7e17-b3ba-279aba211018" name="Ithilmar weapon" page="0" hidden="false">
-      <description>An ithilmar weapon gives its user +1 Initiative in hand-to-hand combat, and costs three times the price of a normal weapon of its kind.</description>
-    </rule>
-    <rule id="e23bd4fb-c553-13cf-2ab8-252167663a44" name="Leader" page="0" hidden="false">
-      <description>All Models within 6&quot; of leader can use the leaders leadership when taking leadership tests.</description>
-    </rule>
-    <rule id="da91afee-2f0d-cbc1-78ff-c6bdec885712" name="Move Of Fire" page="0" hidden="false">
-      <description>You may not move and fire a  in the same turn,other than to pivot on the spot to face your target or stand up.</description>
-    </rule>
     <rule id="75a2f07b-eab8-01aa-de76-d15f38bfb34e" name="Mutations" hidden="false">
       <description>May start the game with one or more mutations(mutants must have at least 1)</description>
-    </rule>
-    <rule id="f1630f42-6b8b-0d73-b6a6-d2626cd8839b" name="Parry" page="0" hidden="false">
-      <description>A model equipped with a parry weapon may parry the first blow in each round of hand-to-hand combat. When his opponent scores a hit, a model with a may roll 1D6. If the score is greater than the highest to hit score of his opponent, the model has parried the blow, and that attack is discarded. A model may not parry attacks made with double or more its own Strength – they are simply too powerful to be stopped.</description>
-    </rule>
-    <rule id="f7723056-9cfe-c405-d7e6-357321f7dca3" name="Prepare shot" page="0" hidden="false">
-      <description>Takes a whole turn to reload, so you may only fire every other turn. If you have a brace of pistols (ie, two) you may fire every turn.</description>
-    </rule>
-    <rule id="3fa1d399-e681-411c-ebf6-c53c307e749a" name="Strike First" page="0" hidden="false">
-      <description>A warrior with Strike First strikes first in the first turn of hand-to-hand combat</description>
-    </rule>
-    <rule id="a9f238c7-bf82-807c-f964-888f9c9d0f26" name="Strike Last" page="0" hidden="false">
-      <description>weapons are so heavy that the model using them always strikes last, even when charging.</description>
-    </rule>
-    <rule id="cd0edb82-a80c-4679-2376-f34a11dc840e" name="Stupidity" page="0" hidden="false">
-      <description>Models that are stupid test leadership (2d6) at the start of their turn to see if they overcome their stupidity. 
-If failed, until the start of his next turn (when it takes a new Stupidity test) the model will not cast spells or fight in hand-to-hand combat (though his opponent will still have to roll to
-hit him as normal).
-
-
-If a model who fails a Stupidity test is not in hand-tohand
-combat, roll a D6.
-1-3 The warrior moves directly forward at half speed in a shambling manner. He will not charge an enemy (stop his movement 1&quot; away)  He can fall down from the edge of a sheer drop (see the Falling rules) or hit an obstacle, in which case he stops. The model will not shoot this turn.
-
-4-6 The warrior stands inactive and drools a bit during this turn.</description>
-    </rule>
-    <rule id="58c7eaa3-75c5-8aad-7374-f0275b30848d" name="Two Handed" page="0" hidden="false">
-      <description>model armed with a 2handed weapon may not use a shield, buckler or additional weapon in close combat. If the model has a shield he still gets a +1 bonus to his armour save against shooting.</description>
-    </rule>
-    <rule id="be37b096-f38b-d3f0-0c72-f18572a56f1d" name="Unwieldy:" page="0" hidden="false">
-      <description>A weapon with Unwieldy may only use a shield or a buckler in his other hand. He may not use a second weapon.</description>
     </rule>
   </sharedRules>
   <catalogueLinks>

--- a/common-data.cat
+++ b/common-data.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e020-c282-277b-b173" name="common-data" revision="25" battleScribeVersion="2.03" library="true" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="e020-c282-277b-b173" name="common-data" revision="26" battleScribeVersion="2.03" library="true" gameSystemId="9481a749-7900-614b-1695-bdc2899069c1" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry id="d769-0d85-e810-df60" name="Experience" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
@@ -344,104 +344,6 @@ Warhorses only.</description>
           </characteristics>
         </profile>
       </profiles>
-      <selectionEntries>
-        <selectionEntry id="96e2-52dd-cc05-0fb0" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="15"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8fca-96e6-e28f-3fe9" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d1ca-f11b-5ffa-f90e" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="6888-9f16-8a8f-265c" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8fca-96e6-e28f-3fe9" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="10"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="96e2-52dd-cc05-0fb0" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e1f9-7a38-53ab-9dc0" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="b649-1aa9-9903-4e1e" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Obsidian Weapon" hidden="false" id="57f0-c15a-15eb-f82c" page="0" collective="false">
-          <modifiers>
-            <modifier type="set" value="50" field="points"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="d934-5ef1-ce0d-9f6d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="6cdf-a5a6-dcb9-f01e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-          </constraints>
-          <infoLinks>
-            <infoLink name="Obsidian Weapon" id="0734-c936-5d71-3c33" hidden="false" type="rule" targetId="18e0-c1f2-9595-f19a"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="5"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -450,7 +352,7 @@ Warhorses only.</description>
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="2cda-8ede-6864-bb0d" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="cd57-dd4b-0a49-03e6" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
-        <entryLink import="true" name="Obsidian weapon" hidden="false" id="37e8-d2ee-a87d-ebfa" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="7c7a-f75a-ef9b-682c" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="ae81-7b68-5718-38e1" name="Ball and Chain" page="0" hidden="true" collective="false" import="true" type="upgrade">
@@ -519,77 +421,6 @@ ignores the special rules for Animosity.</description>
       <infoLinks>
         <infoLink id="efd9-a513-0429-1183" name="+1 Enemy armour save" hidden="false" targetId="98ac-2376-00c1-4f65" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="d8d9-e2c3-f257-0138" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="6"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="9a0c-5970-0d85-7743" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="77e5-4006-54c3-0f3a" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="edeb-42e8-74ea-a221" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9a0c-5970-0d85-7743" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="4"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="9a0c-5970-0d85-7743" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d61-c656-9a48-f2fc" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="1133-aa81-6e29-23d9" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="2"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -598,6 +429,7 @@ ignores the special rules for Animosity.</description>
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="6e6f-eb85-a18a-316d" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="88a9-9057-b107-4cc0" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="305e-544e-849b-ce30" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="a0a1-b311-e3aa-6c3b" name="Double Handed Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -613,77 +445,16 @@ ignores the special rules for Animosity.</description>
         <infoLink id="1c14-2ef7-3a5f-ce34" name="Strike Last" hidden="false" targetId="a365-c068-5790-d61d" type="rule"/>
         <infoLink id="24a9-f38e-b775-7b5b" name="Two Handed" hidden="false" targetId="2fb3-525b-86c3-2cd6" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="7ef9-e43e-bc90-4baf" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="45"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="23be-e9cd-f8e8-e6d5" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="23a0-a3f3-7815-4349" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="d6bc-3d8b-693e-031e" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="23be-e9cd-f8e8-e6d5" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="7ef9-e43e-bc90-4baf" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9e43-911f-7310-d8c5" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="9b71-3396-bb91-197b" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="15"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
+      <entryLinks>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="57cf-7a27-ab41-3e7a" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="bbfd-75d6-2065-18c5" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="6eb9-db4a-b01d-6af8" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="eb7b-b5c6-d4f2-80e5" name="Fist" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -719,80 +490,15 @@ ignores the special rules for Animosity.</description>
         <infoLink id="7cd4-ca17-c76c-99a0" name="Heavy" hidden="false" targetId="c097-af8b-c2de-ac04" type="rule"/>
         <infoLink id="0bdf-fd1e-9108-453f" name="Two Handed" hidden="false" targetId="2fb3-525b-86c3-2cd6" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="dd42-b744-e614-9fc8" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="45"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="9eea-481f-cd5f-a837" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="494e-45b1-ecd7-44c3" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="8ad4-590a-b005-263b" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9eea-481f-cd5f-a837" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="dd42-b744-e614-9fc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9b1f-8d60-2e38-8193" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="096f-9471-bdf8-5476" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="15"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Gromril Weapon" hidden="false" id="5e96-6c17-4a69-b564" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
-        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="e2ab-ef89-32c7-5169" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="91ce-5a31-ac7c-c485" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="bdb3-6904-c55c-bb5a" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="3c2e-faf7-7f7b-7dac" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="0d0b-ed37-d8b0-4cbf" name="Free Dagger" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -828,72 +534,6 @@ ignores the special rules for Animosity.</description>
       <infoLinks>
         <infoLink id="a20d-4767-d8c6-8fc2" name="Two Handed" hidden="false" targetId="2fb3-525b-86c3-2cd6" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="600f-da85-131f-4fcf" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="a8eb-06cb-ec86-9dde" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f5d9-a626-df95-a138" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="bf73-aefe-e15a-8efa" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a8eb-06cb-ec86-9dde" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="20"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="600f-da85-131f-4fcf" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a887-4e31-d7f3-2955" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="c990-6086-8d88-ad45" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="10"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -902,6 +542,7 @@ ignores the special rules for Animosity.</description>
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="7ce8-6edc-de69-88b0" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="d2ec-26ae-aa6f-46fe" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="048c-f409-b2be-a466" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="cfcc-39fd-aeb4-876a" name="Hammer" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -916,104 +557,6 @@ ignores the special rules for Animosity.</description>
       <infoLinks>
         <infoLink id="cab8-4d87-fe08-7e99" name="Concussion" hidden="false" targetId="f08e-fc7a-fca1-6a49" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="a426-2692-1542-8732" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="9"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="95f9-d3b5-cb11-b3cc" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="771b-d8b1-41c7-e5f5" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="9e3f-8f62-928c-cee9" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="95f9-d3b5-cb11-b3cc" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="6"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="a426-2692-1542-8732" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="46ef-937b-66c8-a88d" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="3029-86ae-0e82-3a31" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Obsidian Weapon" hidden="false" id="a1d0-5e45-e1c1-f06a" page="0" collective="false">
-          <modifiers>
-            <modifier type="set" value="50" field="points"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="d934-5ef1-ce0d-9f6d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="dd3d-1274-01d2-2f7f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-          </constraints>
-          <infoLinks>
-            <infoLink name="Obsidian Weapon" id="3b6d-122f-8e55-2aaf" hidden="false" type="rule" targetId="18e0-c1f2-9595-f19a"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="3"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -1022,7 +565,7 @@ ignores the special rules for Animosity.</description>
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="90e8-0377-23c2-c8d3" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="06f0-0b43-9d98-f218" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
-        <entryLink import="true" name="Obsidian weapon" hidden="false" id="ecb4-591e-3aaa-42da" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="3152-9084-fb45-542b" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="5223-13a6-14ec-f372" name="Lance" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1043,80 +586,15 @@ ignores the special rules for Animosity.</description>
         <infoLink id="3199-95e9-e684-ab68" name="Cavalry bonus" hidden="false" targetId="ef77-8d02-8707-afc4" type="rule"/>
         <infoLink id="0c3d-a4da-6abc-80ef" name="Cavalry Weapon" hidden="false" targetId="033a-b64b-4bfc-e285" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="9c8e-6817-4b06-c1b4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="120"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="841d-afb5-dea7-19a7" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e5ab-b748-2477-0825" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="07f6-fbf0-39ab-dc6f" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="841d-afb5-dea7-19a7" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="80"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="9c8e-6817-4b06-c1b4" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9221-6fdf-1c0c-25d8" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="ba4e-e5d6-90a8-7ea1" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="40"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="8"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Gromril Weapon" hidden="false" id="fc3e-f7f6-5649-fce0" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
-        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="7328-5002-e362-1d26" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="1655-d936-789c-d758" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="c120-3dd2-186a-b8e0" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="476b-5912-dd6c-288c" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="d5f3-1906-da91-4e8f" name="Morning Star" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1132,80 +610,15 @@ ignores the special rules for Animosity.</description>
         <infoLink id="feee-07cd-3c87-1e7e" name="Difficult to use" hidden="false" targetId="14b3-65c8-02c4-ae65" type="rule"/>
         <infoLink id="a39d-6453-f377-6ebc" name="Heavy" hidden="false" targetId="c097-af8b-c2de-ac04" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="54e5-e4f2-7236-b9cf" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="45"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="c2ad-f717-6be0-4c1f" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="36c9-91ee-416a-5554" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="baa9-a2a9-f583-acb2" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c2ad-f717-6be0-4c1f" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="54e5-e4f2-7236-b9cf" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0905-aa04-200e-e7f3" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="13a6-25a8-7a1f-93f4" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="15"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Gromril Weapon" hidden="false" id="792d-d00a-b243-1759" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
-        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="ec10-1513-e5f3-f68e" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="2cf2-2eda-c0ef-672d" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="d492-315d-5fd9-a0ec" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="4da7-3056-c640-b405" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="005e-e397-8108-f198" name="Spear" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1222,113 +635,15 @@ ignores the special rules for Animosity.</description>
         <infoLink id="23fd-7ecb-f62b-d301" name="Strike First" hidden="false" targetId="744d-bb7c-09b9-ab1c" type="rule"/>
         <infoLink id="4e58-2513-010b-b28f" name="Unwieldy" hidden="false" targetId="2b45-f8c1-de87-638f" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="3529-c0de-1ce6-c915" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="3e97-e8c7-1a72-b617" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="139b-08ab-d0b1-3d0d" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="a482-d72a-b902-1922" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3e97-e8c7-1a72-b617" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="20"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="3529-c0de-1ce6-c915" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bdf2-f4ed-0421-b123" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="62cc-9ba6-60eb-5f5d" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Obsidian Weapon" hidden="false" id="ecfa-e66c-e233-dee5" page="0" collective="false">
-          <modifiers>
-            <modifier type="set" value="50" field="points"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="d934-5ef1-ce0d-9f6d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="d8f7-12e2-5ef7-8b91" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-          </constraints>
-          <infoLinks>
-            <infoLink name="Obsidian Weapon" id="fa55-04f4-621b-b1ff" hidden="false" type="rule" targetId="18e0-c1f2-9595-f19a"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="10"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Gromril Weapon" hidden="false" id="58b7-824f-9a18-1766" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
-        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="67ec-f365-6f6f-f328" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
-        <entryLink import="true" name="Obsidian weapon" hidden="false" id="6caa-72df-4f30-6bbb" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="d173-18f8-b89c-a4bb" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="5697-aebe-430a-d36c" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="04bb-5eda-973f-f5f1" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="34fd-d6a3-50ee-ee06" name="Sword" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1343,113 +658,15 @@ ignores the special rules for Animosity.</description>
       <infoLinks>
         <infoLink id="fda2-d73b-5b2a-4ede" name="Parry" hidden="false" targetId="17dc-9c49-08e1-af45" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="5115-a954-b8d7-b4a0" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="d934-5ef1-ce0d-9f6d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d01-3554-4ccb-4b89" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="5c0a-a657-3504-dea2" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d934-5ef1-ce0d-9f6d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="20"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="5115-a954-b8d7-b4a0" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2348-f738-5385-fffb" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="b48d-66a3-be35-7624" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Obsidian Weapon" hidden="false" id="cb60-c643-b4d2-a9b2" page="0" collective="false">
-          <modifiers>
-            <modifier type="set" value="50" field="points"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="d934-5ef1-ce0d-9f6d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="8a12-3fee-6689-41d8" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-          </constraints>
-          <infoLinks>
-            <infoLink name="Obsidian Weapon" id="4c1e-b37d-36b3-5173" hidden="false" type="rule" targetId="18e0-c1f2-9595-f19a"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="10"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Gromril Weapon" hidden="false" id="ad54-e0b7-d487-ab7d" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
-        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="75c8-7ccf-b27e-f73c" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
-        <entryLink import="true" name="Obsidian weapon" hidden="false" id="e03d-397b-2b75-c005" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="9b3e-d263-db0b-5dae" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="f72e-aaf9-18b5-1cb0" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="4250-6f46-5d96-df47" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="4386-7400-9146-1dee" name="Blunderbuss" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1794,7 +1011,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c382-8a60-6e48-6d01" includeChildSelections="false"/>
       </constraints>
     </selectionEntry>
-    <selectionEntry id="3706-6421-53b4-940d" name="Shortbow" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="3706-6421-53b4-940d" name="Short Bow" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="6bae-8763-feca-a52f" name="Shortbow" page="0" hidden="false" typeId="c4b0233c-e5d1-2b41-3446-45a745fbbbec" typeName="Ranged Weapon">
           <characteristics>
@@ -1865,7 +1082,7 @@ If the model fires twice then each shot is at -1 to hit.</description>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e4b6-11e1-5e33-ecda" includeChildSelections="false"/>
       </constraints>
     </selectionEntry>
-    <selectionEntry id="f122-5313-bc4d-97fa" name="Holy (Unholy) Relic" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="f122-5313-bc4d-97fa" name="Holy Relic" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="a7ab-e8fb-dbf2-fa6a" name="Holy (Unholy) Relic" page="0" hidden="false">
           <description>A model with a holy relic will automatically pass the first Leadership test he is required to make in the game.
@@ -2636,6 +1853,11 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="0c80-e5ef-375a-ed02" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="1bbd-eaae-deac-6d8f" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="a084-3c65-8303-7def" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="7c61-2104-517e-dfab" name="Horseman&apos;s Hammer" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -2663,6 +1885,7 @@ a -2 save modifier, regardless of the firer’s Strength.</description>
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="2a59-d487-d7eb-10cc" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="da9a-d332-0bd2-4a43" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="5d21-9eea-5ecf-fe2f" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="065e-ad0a-c227-a634" name="Torch" hidden="false" collective="false" import="true" type="upgrade">
@@ -2702,70 +1925,6 @@ Any models that have a Regeneration special rule (like Trolls) will not be able 
         <infoLink id="7d3e-b6ec-8c12-2d9e" name="Pair" hidden="false" targetId="f053-2d68-666e-727a" type="rule"/>
         <infoLink id="cb31-a8c7-6c39-c9ef" name="Parry" hidden="false" targetId="17dc-9c49-08e1-af45" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="3e8b-5a2a-9a18-9976" name="Gromril Weapon" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c611-d517-ae82-a126" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="00a4-5e95-3013-149e" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="105"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="5493-79c3-5d89-9a3c" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </selectionEntry>
-        <selectionEntry id="5493-79c3-5d89-9a3c" name="Ithilmar Weapon" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a764-a461-96f1-a48d" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="c31f-d1fd-5c61-bc2d" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="70"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="3e8b-5a2a-9a18-9976" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="35"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -2782,6 +1941,11 @@ Any models that have a Regeneration special rule (like Trolls) will not be able 
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="954e-4ec4-4944-6174" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="a752-af4d-177b-550a" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="99ca-e634-6103-09ec" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="c51a-d060-7bf2-7ae3" name="Warplock Pistol" hidden="true" collective="false" import="true" type="upgrade">
       <profiles>
@@ -2826,15 +1990,13 @@ Any models that have a Regeneration special rule (like Trolls) will not be able 
         </profile>
       </profiles>
       <rules>
-        <rule id="1f10-7bce-3349-758f" name="Holy Weapon" page="0" hidden="false">
-          <description>The warhammer has a +1 bonus on all to wound rolls against any Possessed or Undead models.
-Note that you will still need to score a 6 before any modifiers in order to cause a critical hit.
-
-Only Matriarchs and Sister Superiors may carry two Sigmarite  warhammers.</description>
+        <rule id="1f10-7bce-3349-758f" name="Duel Wielding Restriction" page="0" hidden="false">
+          <description>Only Matriarchs and Sister Superiors may carry two Sigmarite warhammers.</description>
         </rule>
       </rules>
       <infoLinks>
         <infoLink id="d274-6e56-4bde-daeb" name="Concussion" hidden="false" targetId="f08e-fc7a-fca1-6a49" type="rule"/>
+        <infoLink name="Holy" id="3327-db88-426c-84e6" hidden="false" type="rule" targetId="b80b-8ee2-dcf6-ef2d"/>
       </infoLinks>
       <costs>
         <cost name=" gc" typeId="points" value="15"/>
@@ -2885,6 +2047,7 @@ Only Matriarchs and Sister Superiors may carry two Sigmarite  warhammers.</descr
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="8eaf-e13b-86c1-5fdd" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="0d0e-65be-b471-8d45" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="8786-3a37-9f90-31df" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="79b7-5cfb-549c-c973" name="Gnoblar Fighter" hidden="false" collective="false" import="true" type="upgrade">
@@ -3183,6 +2346,11 @@ Because it does not require prepared shot, this bonus attack may be used in each
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="a3c0-13de-ceaf-9799" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="a6bf-b53b-ef2d-2559" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="70df-c7f7-2cdb-a5ed" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="bb96-6dc1-2f2f-b4c" name="Tufenk" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -3259,73 +2427,6 @@ Khemri setting</description>
         <infoLink id="84a8-ae0a-94d1-c16b" name="Cutting edge" hidden="false" targetId="4b68-6905-29fd-e549" type="rule"/>
         <infoLink id="d921-f56c-d92c-7cc4" name="Parry" hidden="false" targetId="17dc-9c49-08e1-af45" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="64ac-221e-35f1-5c3f" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="60"/>
-            <modifier type="set" field="points" value="45"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="bc24-c66d-6b4e-466b" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1213-7c57-fac5-647f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="56c2-ba58-f5e1-7da1" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="bc24-c66d-6b4e-466b" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="45"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="64ac-221e-35f1-5c3f" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ffb-eaf3-c1b1-5d12" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="a007-d2a6-bef0-7bea" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="15"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -3344,6 +2445,11 @@ Khemri setting</description>
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="3ae1-3bec-d17b-5401" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="13ff-6b79-831d-61b5" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="ca47-51e4-94aa-ca5d" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="b6b-2ea5-1f65-a84b" name="Blowpipe" hidden="true" collective="false" import="true" type="upgrade">
       <profiles>
@@ -3527,72 +2633,6 @@ The model can change to normal hand-to-hand weapons after the initial round.</
 Additionally, only 1 attack is allowed, no matter the number on the wielder’s profile.</description>
         </rule>
       </rules>
-      <selectionEntries>
-        <selectionEntry id="5b19-5021-8598-9cf" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="b7cc-2cd1-1613-6a28" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b936-89c5-2023-2368" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="90c8-99c1-cb29-2aca" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b7cc-2cd1-1613-6a28" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="20"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="5b19-5021-8598-9cf" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef5c-e2c6-61f9-aebb" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="329-e5eb-18f7-2b5f" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="12"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -3611,6 +2651,11 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="b081-97b2-fc9d-2967" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="829b-c5e1-db70-bb65" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="2604-c4ee-328c-f303" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="5487-85f6-ae5f-dac1" name="Scythe" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -3632,6 +2677,7 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="5461-16a4-549e-8108" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="43cf-63f4-8992-3e40" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="0fc2-b30f-7472-3c92" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="583e-a0c5-873-acdc" name="Advancement (Henchmen)" hidden="false" collective="false" import="true" type="upgrade" collapsible="true">
@@ -3747,6 +2793,11 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="1ac0-1800-502e-a504" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="4318-806d-8d30-3483" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="08f6-4e40-f658-4a32" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="7214-9103-e23e-45ac" name="Staff" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -3760,72 +2811,6 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
       <infoLinks>
         <infoLink id="8865-6a27-e27a-c792" name="Concussion" hidden="false" targetId="f08e-fc7a-fca1-6a49" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="97f5-e984-1dd2-9332" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="9"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="cde3-4e6c-198f-e684" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f7a-0f6f-944f-b092" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="51bb-4743-f1e4-d759" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="cde3-4e6c-198f-e684" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="6"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="97f5-e984-1dd2-9332" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe6c-56db-eeb0-6b2f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="d7d3-738e-be4f-4caa" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="3"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -3834,6 +2819,7 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="3764-e8b0-4453-2de7" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="c715-d891-e9f0-76df" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="77f1-64a3-63e8-fc38" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="2cbb-013b-3ebf-0459" name="Mace" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3848,80 +2834,15 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
       <infoLinks>
         <infoLink id="0634-c5c4-419f-d767" name="Concussion" hidden="false" targetId="f08e-fc7a-fca1-6a49" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="f274-a72b-86dd-ae4c" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="9"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="12a8-af97-e37f-baf1" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b4bb-a8a3-54ca-c05f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="acf2-34ce-a48c-744f" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="12a8-af97-e37f-baf1" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="6"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="f274-a72b-86dd-ae4c" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a877-87e6-6041-bf13" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="5296-2f8c-742d-5f19" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="3"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Gromril Weapon" hidden="false" id="99f8-7273-a9e5-c592" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
-        <entryLink import="true" name="Ithilmar weapon" hidden="false" id="5329-db03-f822-e2be" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="ee7d-a955-853a-74ac" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="d949-6d53-ab59-b8a0" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="c53b-9393-848f-413c" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="b43f-0d15-1f20-7fda" name="Club" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -3936,72 +2857,6 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
       <infoLinks>
         <infoLink id="02ac-3e73-bd26-21d2" name="Concussion" hidden="false" targetId="f08e-fc7a-fca1-6a49" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="8f4f-5b36-9995-12c7" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="9"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="29e7-2ba3-a1be-abde" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e51-d98a-c8fa-0054" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="0cd3-ce52-df5d-b75f" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="29e7-2ba3-a1be-abde" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="6"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8f4f-5b36-9995-12c7" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ff5-b0e9-f4c5-cf91" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="72bd-5d10-a906-15c9" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="3"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -4010,6 +2865,7 @@ Additionally, only 1 attack is allowed, no matter the number on the wielder’s 
       <entryLinks>
         <entryLink import="true" name="Gromril Weapon" hidden="false" id="8770-2a6f-504c-ae3e" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="e46b-eb27-37c7-a5dc" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian weapon" hidden="false" id="7d36-9546-b48b-b7ce" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Sunstaff (Lustria)" hidden="true" id="7537-ac89-b499-e6d0" collective="false">
@@ -4103,6 +2959,11 @@ It is a close combat weapon and attacks like a dagger but can parry the first su
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="d94a-55f8-ca02-f615" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="f8ac-53b9-fd8d-64a8" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="3187-46a2-09aa-f674" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Starsword" hidden="true" id="1f34-eeff-387e-70bb" collective="false" page="0">
       <profiles>
@@ -4143,6 +3004,11 @@ The Sword confers a bonus of +1 Strength and ignores all armour saves except for
           </conditionGroups>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="4fa9-265d-40be-b6e0" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="b0c5-bb65-f421-42af" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="4b50-3026-1877-2bf6" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="0a36-4063-32b7-61b3" name="Weeping Blades" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <profiles>
@@ -4158,72 +3024,6 @@ The Sword confers a bonus of +1 Strength and ignores all armour saves except for
         <infoLink name="Pair" id="ecf6-08aa-e5ff-cf3e" hidden="false" targetId="f053-2d68-666e-727a" type="rule"/>
         <infoLink name="Pair" id="ce86-d79a-7d99-092f" hidden="false" targetId="f053-2d68-666e-727a" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="0ad6-c241-32e2-e03d" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="150"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="58ff-ede1-977c-911d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a8d-e987-0246-e3a2" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="372b-af8d-bc7c-9ba4" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="58ff-ede1-977c-911d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="100"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="0ad6-c241-32e2-e03d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6c46-34ca-32a6-f2ad" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="be9c-4b7b-f39f-9641" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="50"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -4243,82 +3043,21 @@ The Sword confers a bonus of +1 Strength and ignores all armour saves except for
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b4f0-dd9b-1ad4-0ab3"/>
       </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="189a-4c57-2b24-3a17" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="5d6e-987c-32aa-7e0e" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="811d-10d8-eafd-b9ff" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="1ce7-1431-21fc-6d18" name="Steel Whip" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="f812-a959-3777-307a" name="Sword" page="0" hidden="false" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon">
+        <profile name="Steel Whip" typeId="9db87680-6ee5-b46c-48ca-dcd1c5de1bad" typeName="HtH Weapon" hidden="false" id="e555-f94d-7259-73f6">
           <characteristics>
-            <characteristic name="Str" typeId="f10cfcb7-b71e-4c27-9836-75d341e28f68">As user</characteristic>
-            <characteristic name="Special" typeId="80dd3fd5-3811-af0b-e182-2ecbc7ad5d8e">Parry</characteristic>
+            <characteristic name="Str" id="3b64-8d8c-baf3-6b02" hidden="false" typeId="f10cfcb7-b71e-4c27-9836-75d341e28f68">As User</characteristic>
+            <characteristic name="Special" id="0b45-aab0-e62c-6bc1" hidden="false" typeId="80dd3fd5-3811-af0b-e182-2ecbc7ad5d8e">Cannot be Parried, Whipcrack</characteristic>
           </characteristics>
         </profile>
       </profiles>
-      <selectionEntries>
-        <selectionEntry id="e336-ea08-bf25-8874" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="30"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="6b4f-fcc6-22f7-252d" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54aa-6bcc-abc4-22a8" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="cb28-5be1-b78d-d130" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6b4f-fcc6-22f7-252d" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="20"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e336-ea08-bf25-8874" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8524-8b43-53f9-c056" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="eb36-a888-0ddf-bccd" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="10"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -4344,6 +3083,11 @@ The Sword confers a bonus of +1 Strength and ignores all armour saves except for
           <description>When the wielder charges they gain +1A for that turn. This bonus attack is added after any other modifications. When the wielder is charged they gain +1A that they may only use against the charger. This additional attack will &apos;strike first&apos;. If the wielder is simultaneously charged by two or more opponents they will still only receive a total of +1A. If the wielder is using two whips at the same time then they get +1A for the additional hand weapon, but only the first whip gets the whipcrack +1A.</description>
         </rule>
       </rules>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="e27c-2e3a-836c-af0f" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="4441-dd85-b494-0308" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="9171-816d-0bc8-17ac" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="6de3-e855-8fb4-ce53" name="Wolfcloak" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <rules>
@@ -4402,72 +3146,6 @@ The Sword confers a bonus of +1 Strength and ignores all armour saves except for
       <infoLinks>
         <infoLink id="081b-8518-92ff-75cc" name="Parry" hidden="false" targetId="17dc-9c49-08e1-af45" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="0613-60c3-1734-c9a4" name="Gromril Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="90"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="e598-bbe8-6558-9de5" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5f7-6f21-a876-5496" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="7286-02ef-37e6-0746" name="Gromril weapon" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e598-bbe8-6558-9de5" name="Ithilmar weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="points" value="60"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="0613-60c3-1734-c9a4" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c64-da83-c0a1-de9d" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="a58c-171e-6908-78e8" name="Ithilmar weapon" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name=" gc" typeId="points" value="0"/>
-            <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-            <cost name=" Rarity" typeId="rarity" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <costs>
         <cost name=" gc" typeId="points" value="30"/>
         <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
@@ -4480,6 +3158,11 @@ The Sword confers a bonus of +1 Strength and ignores all armour saves except for
 Not available to Possessed or Undead.</description>
         </rule>
       </rules>
+      <entryLinks>
+        <entryLink import="true" name="Gromril Weapon" hidden="false" id="2584-55a1-3b76-73d5" type="selectionEntry" targetId="cb4e-de46-b048-02d9"/>
+        <entryLink import="true" name="Ithilmar Weapon" hidden="false" id="0593-6eec-db48-628b" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
+        <entryLink import="true" name="Obsidian Weapon" hidden="false" id="0c35-9225-4591-ee2f" type="selectionEntry" targetId="8e77-6886-8b6e-2124"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Chaos Dwarf Blunderbuss" hidden="false" id="f425-ed8a-06d6-57b6" page="0" collective="false">
       <profiles>
@@ -4551,11 +3234,6 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <entryLink import="true" name="Ithilmar weapon" hidden="false" id="8fd8-30ce-010a-5f26" type="selectionEntry" targetId="f797-886a-f53d-b770"/>
       </entryLinks>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="First mutation" hidden="false" id="bc0f-5f4b-4a70-6320">
-      <constraints>
-        <constraint type="max" value="1" field="selections" scope="model" shared="true" id="abea-14a7-c3de-8b43" includeChildSelections="true"/>
-      </constraints>
-    </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Gromril Weapon" hidden="false" id="cb4e-de46-b048-02d9" page="0" collective="false">
       <modifiers>
         <modifier type="multiply" value="4" field="points" scope="parent"/>
@@ -4563,11 +3241,6 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <modifier type="set" value="true" field="hidden">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="parent" childId="f797-886a-f53d-b770" shared="true" childName="Ithilmar weapon"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditions>
-            <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
           </conditions>
         </modifier>
         <modifier type="set" value="true" field="hidden">
@@ -4588,18 +3261,13 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Ithilmar weapon" hidden="false" id="f797-886a-f53d-b770" page="0" collective="false">
+    <selectionEntry type="upgrade" import="true" name="Ithilmar Weapon" hidden="false" id="f797-886a-f53d-b770" page="0" collective="false">
       <modifiers>
         <modifier type="multiply" value="3" field="points" scope="parent"/>
         <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
         <modifier type="set" value="true" field="hidden">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="parent" childId="cb4e-de46-b048-02d9" shared="true" childName="Gromril Weapon"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditions>
-            <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
           </conditions>
         </modifier>
         <modifier type="set" value="true" field="hidden">
@@ -4620,18 +3288,13 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <cost name=" Rarity" typeId="rarity" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Obsidian weapon" hidden="false" id="8e77-6886-8b6e-2124" page="0" collective="false">
+    <selectionEntry type="upgrade" import="true" name="Obsidian Weapon" hidden="false" id="8e77-6886-8b6e-2124" page="0" collective="false">
       <modifiers>
         <modifier type="multiply" value="4" field="points" scope="parent"/>
         <modifier type="prepend" value="Obsidian" field="name" scope="parent"/>
         <modifier type="set" value="true" field="hidden">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="parent" childId="cb4e-de46-b048-02d9" shared="true" childName="Gromril Weapon"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditions>
-            <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
           </conditions>
         </modifier>
         <modifier type="set" value="true" field="hidden">
@@ -4644,19 +3307,15 @@ Any and all models in its path are automatically hit by a Strength 3 hit.</descr
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="60bf-c49b-1ec7-3898" includeChildSelections="false"/>
       </constraints>
       <rules>
-        <rule name="Pair" id="9834-76a3-fb42-e483" hidden="false">
-          <description>Poisoned Daggers are traditionally used in pairs, one in each hand. A warrior armed with Poisoned Daggers gets an additional attack (for the offhand weapon attack).</description>
-        </rule>
-        <rule name="Swift" id="e681-afb4-d20e-beb0" hidden="false">
-          <description>Hobgoblins armed with Poisoned Daggers count as having +1 Initiative when determining combat order</description>
-        </rule>
-        <rule name="Rarity" id="e439-25be-7ef4-f670" hidden="false">
-          <description>Rare 9 (Hobgoblins only)</description>
-        </rule>
-        <rule name="Poisoned" id="c29d-3515-f790-4273" hidden="false">
-          <description>The venom of Poisoned Daggers will enter the blood of the victim and ravage his organs and muscles. The weapons count as being permanently coated in Black Lotus (6 to hit causes automatic wound, still roll to wound and if 6 to wound causes critical hit otherwise its a normal wound). No additional poison may be applied to Poisoned Daggers. Take armour saves as normal</description>
+        <rule name="Rarity" id="f623-6003-def7-5611" hidden="false">
+          <description> Rare 12</description>
         </rule>
       </rules>
+      <infoLinks>
+        <infoLink name="Obsidian Weapon" id="eb26-f17d-3192-c913" hidden="false" type="rule" targetId="18e0-c1f2-9595-f19a"/>
+        <infoLink name="Heavy" id="7d24-4d2e-58be-403d" hidden="false" type="rule" targetId="c097-af8b-c2de-ac04"/>
+        <infoLink name="Blemished" id="4c3a-8643-5999-6b1a" hidden="false" type="rule" targetId="de9b-5c4a-9c08-f65c"/>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="First mutation" hidden="false" id="bc0f-5f4b-4a70-6320">
       <constraints>
@@ -5565,72 +4224,6 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
               </conditions>
             </modifier>
           </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Ithilmar weapon" hidden="false" id="0f4a-d56b-7b5d-1344" page="0" collective="false">
-              <modifiers>
-                <modifier type="set" value="30" field="points"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="0de3-864b-9757-1a67" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="138c-8ea4-d143-8632" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-              </constraints>
-              <infoLinks>
-                <infoLink name="Ithilmar weapon" id="20d3-ded2-3a97-ec81" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name=" gc" typeId="points" value="0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-                <cost name=" Rarity" typeId="rarity" value="0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Gromril Weapon" hidden="false" id="0de3-864b-9757-1a67" page="0" collective="false">
-              <modifiers>
-                <modifier type="set" value="45" field="points"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="0f4a-d56b-7b5d-1344" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="9c13-b320-0bfa-2b54" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-              </constraints>
-              <infoLinks>
-                <infoLink name="Gromril weapon" id="6f70-d18c-649f-3d1d" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name=" gc" typeId="points" value="0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-                <cost name=" Rarity" typeId="rarity" value="0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
         </entryLink>
         <entryLink import="true" name="Horseman&apos;s Hammer" hidden="false" id="8a2c-6a73-be64-ab57" type="selectionEntry" targetId="7c61-2104-517e-dfab">
           <modifiers>
@@ -5640,72 +4233,6 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
               </conditions>
             </modifier>
           </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Ithilmar weapon" hidden="false" id="8f85-1600-296a-9b36" page="0" collective="false">
-              <modifiers>
-                <modifier type="set" value="45" field="points"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="e142-2647-c8bd-5bbc" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="05ab-620f-5d5a-d9cb" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-              </constraints>
-              <infoLinks>
-                <infoLink name="Ithilmar weapon" id="f5c9-4bce-edf1-ce9a" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name=" gc" typeId="points" value="0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-                <cost name=" Rarity" typeId="rarity" value="0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Gromril Weapon" hidden="false" id="e142-2647-c8bd-5bbc" page="0" collective="false">
-              <modifiers>
-                <modifier type="set" value="90" field="points"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="8f85-1600-296a-9b36" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="4b73-b6d9-d715-edca" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-              </constraints>
-              <infoLinks>
-                <infoLink name="Gromril weapon" id="4649-1b22-98c0-e702" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name=" gc" typeId="points" value="0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-                <cost name=" Rarity" typeId="rarity" value="0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
         </entryLink>
         <entryLink import="true" name="Rapier" hidden="false" id="03cd-0c51-839b-f24b" type="selectionEntry" targetId="1cad-3ea5-f379-1040">
           <modifiers>
@@ -5715,72 +4242,6 @@ Strength is used for close combat weapons, the bonus applies to all such weapons
               </conditions>
             </modifier>
           </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Gromril Weapon" hidden="false" id="46ea-303f-6d3e-1c66" page="0" collective="false">
-              <modifiers>
-                <modifier type="set" value="45" field="points"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="a8f0-2f48-3c83-9462" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="prepend" value="Gromril" field="name" scope="parent"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="16a3-4023-0d14-435d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-              </constraints>
-              <infoLinks>
-                <infoLink name="Gromril weapon" id="a1fa-6503-2deb-16f9" hidden="false" targetId="fad2-ae3b-6e41-c8b3" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name=" gc" typeId="points" value="0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-                <cost name=" Rarity" typeId="rarity" value="0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ithilmar weapon" hidden="false" id="a8f0-2f48-3c83-9462" page="0" collective="false">
-              <modifiers>
-                <modifier type="set" value="30" field="points"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f9b08d8e-4922-78d5-78ad-2047bff52dc8" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="46ea-303f-6d3e-1c66" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="prepend" value="Ithilmar" field="name" scope="parent"/>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="2247-1f56-bc59-0ead" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="abf8-b2d8-135d-6ca9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-              </constraints>
-              <infoLinks>
-                <infoLink name="Ithilmar weapon" id="430e-4195-c9b2-6dc9" hidden="false" targetId="2c05-eef1-5b96-cc14" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name=" gc" typeId="points" value="0"/>
-                <cost name=" Warband Rating" typeId="wb-rating" value="0"/>
-                <cost name=" Rarity" typeId="rarity" value="0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
         </entryLink>
         <entryLink import="true" name="Weeping Blades" hidden="false" id="d77d-47a7-1215-e1cc" type="selectionEntry" targetId="0a36-4063-32b7-61b3"/>
       </entryLinks>
@@ -6963,7 +5424,7 @@ b) If the model wishes to charge a fearcausing enemy. If a warrior wishes to cha
 Attacks have 4, etc. If a warrior is carrying a weapon in each hand, he receives +1 Attack for this as normal. This extra Attack is not doubled. Once they are within charge range, frenzied warriors are immune to all other psychology, such as fear and don’t have to take these tests as long as they remain within charge range. If a frenzied model is knocked down or stunned, he is
 no longer frenzied. He continues to fight as normal for the rest of the battle.</description>
     </rule>
-    <rule id="fad2-ae3b-6e41-c8b3" name="Gromril weapon" page="0" hidden="false">
+    <rule id="fad2-ae3b-6e41-c8b3" name="Gromril Weapon" page="0" hidden="false">
       <description>A gromril weapon has an extra -1 save modifier, and costs four times the price of a normal weapon of its kind.</description>
     </rule>
     <rule id="fcb5-1485-5135-40ff" name="Hatred" page="0" hidden="false">
@@ -7146,6 +5607,14 @@ If the extra move takes the Orc or Goblin warrior within charge reach of an enem
     <rule name="Obsidian Weapon" id="18e0-c1f2-9595-f19a" hidden="false">
       <description>Strength becomes: As user +1
 A warrior equipped with an obsidian weapon subtracts 1 from his Initiative attribute in melee combat.</description>
+    </rule>
+    <rule name="Blemished" id="de9b-5c4a-9c08-f65c" hidden="false">
+      <description>Although not strictly tainted by Chaos, all obsidian artefacts are considered tinged with evil, by the same darkness associated with their artisans. Obsidian weapons may never be used by Dwarfs, Elves, Sisters of Sigmar, Witch Hunters or Priests.</description>
+    </rule>
+    <rule name="Holy" id="b80b-8ee2-dcf6-ef2d" hidden="false" page="0">
+      <description>This has a +1 bonus on all to wound rolls against any Possessed or Undead models.
+Note that you will still need to score a 6 before any modifiers in order to cause a critical hit.
+</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Short Bow misspelled as "Shortbow"; -fixing again
Henchmen system does not account for equipment costs; - Fixed? Works for dwarfs
Cult of the Possessed: Warband reverted to pre Mel state; - Refresh your data until it comes back (not a thing I can fix more NR/Your app)
Beastmen Raiders: There is a 10 number limit on Ungors; - Fixing again
Beastmen Raiders: Battle Axe misspelled as "Axe"; - not an issue?
Dwarf Treasure Hunters: Gromril weapons not available on Starting Equipment; - Fixed
Dwarf Treasure Hunters: Warband reverted to pre Mel state; - Refresh your data until it comes back (not a thing I can fix more NR/Your app)
Kislevites: Duelling Pistol incorrectly costed at 30gc, should be 25gc for 50gc total; - Maybe put a fix in idk
Marienburgers: Marksmen Henchmen group limit incorrectly written as 1/7; - This is correct https://www.mordheimer.net/docs/warbands/grade-1a-warbands/mercenaries#0--7-marksmen
Middenheimers: Marksmen Henchmen group limit incorrectly written as 1/7; - This is correct https://www.mordheimer.net/docs/warbands/grade-1a-warbands/mercenaries#0--7-marksmen
Reiklanders: Marksmen Henchmen group limit incorrectly written as 1/7; - This is correct https://www.mordheimer.net/docs/warbands/grade-1a-warbands/mercenaries#0--7-marksmen
Sisters of Sigmar: Steel Whip appears as a regular Sword; - Fixing
Sisters of Sigmar: Holy rule misspelled as "Holy Weapon"; - Fixing
Sisters of Sigmar: Holy Relic misspelled as "Holy (Unholy) Relic"; - Fixing
Sisters of Sigmar: Novice Henchmen group limit incorrectly written as 1/10; - This is correct ? Please check to see if this isnt' and if so please put the correct number here as I looked it up via https://www.mordheimer.net/docs/warbands/grade-1a-warbands/sisters-of-sigmar and its 10