### PR TITLE
Fix malformed XML in Ostlanders.cat (doubled slash in two entryLinks)

### DIFF
--- a/Ostlanders.cat
+++ b/Ostlanders.cat
@@ -1227,8 +1227,8 @@
                 <entryLink import="true" name="Blunderbuss" hidden="false" id="9a14-2942-c778-c029" type="selectionEntry" targetId="4386-7400-9146-1dee" sortIndex="5"/>
                 <entryLink import="true" name="Handgun" hidden="false" id="86b2-f467-5d0f-c916" type="selectionEntry" targetId="7f5a-d04d-153d-d334" sortIndex="6"/>
                 <entryLink import="true" name="Hochland Long Rifle" hidden="false" id="bb0c-b540-46ac-f150" type="selectionEntry" targetId="51ed-e371-76d2-d46b" sortIndex="7"/>
-                <entryLink import="true" name="Double Barrelled Pistol" hidden="false" id="a19c-f5ac-d576-5b8b" type="selectionEntry" targetId="b8bb-20cf-ae3a-693f" sortIndex="8"//>
-                <entryLink import="true" name="Double Barrelled Hunting Rifle" hidden="false" id="bf4d-4e54-f8e3-5c41" type="selectionEntry" targetId="5fd9-080e-10f1-9d52" sortIndex="9"//>
+                <entryLink import="true" name="Double Barrelled Pistol" hidden="false" id="a19c-f5ac-d576-5b8b" type="selectionEntry" targetId="b8bb-20cf-ae3a-693f" sortIndex="8"/>
+                <entryLink import="true" name="Double Barrelled Hunting Rifle" hidden="false" id="bf4d-4e54-f8e3-5c41" type="selectionEntry" targetId="5fd9-080e-10f1-9d52" sortIndex="9"/>
               </entryLinks>
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="e905-8a4a-50c3-424e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>


### PR DESCRIPTION
Two self-closing `entryLink` tags in `Ostlanders.cat` (Double Barrelled Pistol and Double Barrelled Hunting Rifle, under Hochland Handgunner) end with `//>` instead of `/>`:

```
... targetId="b8bb-20cf-ae3a-693f" sortIndex="8"//>
... targetId="5fd9-080e-10f1-9d52" sortIndex="9"//>
```

This makes the file ill-formed XML. BattleScribe's own parser tolerates it, but strict XML parsers (Python `ElementTree`, Android `XmlPullParser`, most XML tooling) reject the entire file, so third-party apps that consume this repo can't read the Ostlanders warband at all.

The fix is just the two characters. Verified the file parses cleanly with a strict parser after the change, with no other content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)